### PR TITLE
execute scripts within the page-inner-content div

### DIFF
--- a/packages/saltcorn-mobile-app/www/js/utils/global_utils.js
+++ b/packages/saltcorn-mobile-app/www/js/utils/global_utils.js
@@ -40,10 +40,14 @@ function replaceIframe(content) {
 }
 
 function replaceIframeInnerContent(content) {
-  let iframe = document.getElementById("content-iframe");
-  let iframeDocument = iframe.contentWindow.document;
+  const iframe = document.getElementById("content-iframe");
+  const iframeDocument = iframe.contentWindow.document;
   let innerContentDiv = iframeDocument.getElementById("page-inner-content");
   innerContentDiv.innerHTML = content;
+  let scripts = innerContentDiv.getElementsByTagName("script");
+  for (let script of scripts) {
+    iframe.contentWindow.eval(script.innerHTML);
+  }
 }
 
 function handleRoute(route, query) {


### PR DESCRIPTION
- executes domready tags and the CKEditor will show up, but it should be generally useful, too