### PR TITLE
speed up apk build in container

### DIFF
--- a/deploy/docker-mobile-builder/Dockerfile
+++ b/deploy/docker-mobile-builder/Dockerfile
@@ -32,6 +32,7 @@ ENV CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL=file\:/gradle-7.1.1-all.zip
 RUN cordova build
 
 # prepare entry point
+WORKDIR /
 COPY entry.bash ./
 RUN chmod u+x entry.bash
 ENTRYPOINT ["./entry.bash"]

--- a/deploy/docker-mobile-builder/Dockerfile
+++ b/deploy/docker-mobile-builder/Dockerfile
@@ -18,6 +18,19 @@ RUN wget -q https://services.gradle.org/distributions/gradle-7.1.1-all.zip \
 
 RUN npm install -g cordova
 
+# create an empty project, the first init seems to take longer
+WORKDIR /init_project
+RUN cordova create project
+WORKDIR /init_project/project
+RUN cordova platform add android
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+ENV ANDROID_SDK_ROOT=/android_sdk
+ENV GRADLE_HOME=/opt/gradle-7.1.1
+ENV PATH=$PATH:/opt/gradle-7.1.1/bin
+# stop gradle from downloading itself
+ENV CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL=file\:/gradle-7.1.1-all.zip
+RUN cordova build
+
 # prepare entry point
 COPY entry.bash ./
 RUN chmod u+x entry.bash


### PR DESCRIPTION
- create an empty cordova project while building the image
- gradle seems to download a lot of dependencies on the first init