### PR TITLE
permissions for npm run add-platform

### DIFF
--- a/deploy/docker-mobile-builder/Dockerfile
+++ b/deploy/docker-mobile-builder/Dockerfile
@@ -35,4 +35,8 @@ RUN cordova build
 WORKDIR /
 COPY entry.bash ./
 RUN chmod u+x entry.bash
+
+RUN chmod o+rwx ~
+RUN chmod -R o+rwx ~/.config
+
 ENTRYPOINT ["./entry.bash"]


### PR DESCRIPTION
- npm run changes the user, when run as root, and that user has no permissions for
  /root/.config