### PR TITLE
switching to the v8 coverageProvider

### DIFF
--- a/packages/saltcorn-cli/src/commands/run-tests.js
+++ b/packages/saltcorn-cli/src/commands/run-tests.js
@@ -136,6 +136,7 @@ class RunTestsCommand extends Command {
     let jestParams = ["--"];
     if (flags.coverage) {
       jestParams.push("--coverage");
+      jestParams.push("--coverageProvider", "v8");
     }
     if (flags.testFilter) {
       jestParams.push("-t", flags.testFilter);


### PR DESCRIPTION
- it seems the standard provider (babel) runs out of heap memory
  even with really high max-old-space sizes (just takes a bit longer) or crashes hard
- the v8 provider seems to use way less memory
  https://github.com/facebook/jest/issues/5837#issuecomment-622402792