### PR TITLE
get plugins by the package name

### DIFF
--- a/packages/saltcorn-cli/src/commands/add-schema.js
+++ b/packages/saltcorn-cli/src/commands/add-schema.js
@@ -27,7 +27,7 @@ class AddSchemaCommand extends Command {
       }
     }
     await reset(true);
-    console.log(`Success: Command execution successfully`);
+    console.log(`Successfully ran the 'add-schema' command`);
     this.exit(0);
   }
 }

--- a/packages/saltcorn-cli/src/commands/reset-schema.js
+++ b/packages/saltcorn-cli/src/commands/reset-schema.js
@@ -32,7 +32,7 @@ class ResetCommand extends Command {
         if (ans) await reset(false, schema);
       }
     });
-    console.log(`Success: Command execution successfully`);
+    console.log("Successfully ran the 'reset-schema' command");
     this.exit(0);
   }
 }


### PR DESCRIPTION
- a plugin dependency always uses the @saltcorn prefix, but a plugin can be installed with or without
- for example the html plugin name could be '@saltcorn/html' or 'html'