### PR TITLE
multi_tenant mode in mobile-app

### DIFF
--- a/packages/saltcorn-cli/src/commands/serve.js
+++ b/packages/saltcorn-cli/src/commands/serve.js
@@ -45,6 +45,8 @@ class ServeCommand extends Command {
       const db = require("@saltcorn/data/db");
       db.set_sql_logging();
     }
+    if (flags.subdomain_offset)
+      serveArgs.subdomainOffset = flags.subdomain_offset;
     const serve = require("@saltcorn/server/serve");
     await serve(serveArgs);
   }
@@ -70,6 +72,10 @@ ServeCommand.flags = {
   addschema: flags.boolean({ char: "a", description: "Add schema if missing" }),
   nomigrate: flags.boolean({ char: "n", description: "No migrations" }),
   noscheduler: flags.boolean({ char: "s", description: "No scheduler" }),
+  subdomain_offset: flags.integer({
+    string: "subdomain_offset",
+    description: "Number of parts to remove to access subdomain in 'multi_tenant' mode",
+  }),
 };
 
 module.exports = ServeCommand;

--- a/packages/saltcorn-data/models/view.ts
+++ b/packages/saltcorn-data/models/view.ts
@@ -435,9 +435,6 @@ class View implements AbstractView {
             "X-Requested-With": "XMLHttpRequest",
             "X-Saltcorn-Client": "mobile-app",
           };
-          if (state.mobileConfig?.tenantAppName) {
-            headers["X-Saltcorn-App"] = state.mobileConfig.tenantAppName;
-          }
           const token = window.localStorage.getItem("auth_jwt");
           if (token) headers.Authorization = `jwt ${token}`;
           try {

--- a/packages/saltcorn-data/models/view.ts
+++ b/packages/saltcorn-data/models/view.ts
@@ -425,9 +425,8 @@ class View implements AbstractView {
       : {};
     if (remote) {
       const { getState } = require("../db/state");
-
-      const base_url =
-        getState().getConfig("base_url") || "http://10.0.2.2:3000"; //TODO default from req
+      const state = getState();
+      const base_url = state.getConfig("base_url") || "http://10.0.2.2:3000"; //TODO default from req
       const queries: any = {};
       Object.entries(queryObj).forEach(([k, v]) => {
         queries[k] = async (...args: any[]) => {
@@ -436,6 +435,9 @@ class View implements AbstractView {
             "X-Requested-With": "XMLHttpRequest",
             "X-Saltcorn-Client": "mobile-app",
           };
+          if (state.mobileConfig?.tenantAppName) {
+            headers["X-Saltcorn-App"] = state.mobileConfig.tenantAppName;
+          }
           const token = window.localStorage.getItem("auth_jwt");
           if (token) headers.Authorization = `jwt ${token}`;
           try {

--- a/packages/saltcorn-mobile-app/www/js/utils/global_utils.js
+++ b/packages/saltcorn-mobile-app/www/js/utils/global_utils.js
@@ -27,6 +27,7 @@ async function apiCall({ method, path, params, body, responseType }) {
     "X-Requested-With": "XMLHttpRequest",
     "X-Saltcorn-Client": "mobile-app",
   };
+  if (config.tenantAppName) headers["X-Saltcorn-App"] = config.tenantAppName;
   const token = localStorage.getItem("auth_jwt");
   if (token) headers.Authorization = `jwt ${token}`;
   try {

--- a/packages/saltcorn-mobile-app/www/js/utils/table_utils.js
+++ b/packages/saltcorn-mobile-app/www/js/utils/table_utils.js
@@ -7,7 +7,7 @@ const historyFile = "update_history";
 async function dropDeletedTables(incomingTables) {
   const existingTables = await saltcorn.data.models.Table.find();
   for (const table of existingTables) {
-    if (!incomingTables.find((row) => row.id === table.id)) {
+    if (table.name !== "users" && !incomingTables.find((row) => row.id === table.id)) {
       saltcorn.data.db.query(`DROP TABLE ${table.name}`);
     }
   }

--- a/packages/saltcorn-mobile-builder/mobile-builder.ts
+++ b/packages/saltcorn-mobile-builder/mobile-builder.ts
@@ -42,6 +42,7 @@ export class MobileBuilder {
   copyTargetDir?: string;
   copyFileName?: string;
   buildForEmulator?: boolean;
+  tenantAppName?: string;
 
   /**
    *
@@ -61,6 +62,7 @@ export class MobileBuilder {
     copyTargetDir?: string;
     copyFileName?: string;
     buildForEmulator?: boolean;
+    tenantAppName?: string;
   }) {
     this.templateDir = cfg.templateDir;
     this.buildDir = cfg.buildDir;
@@ -79,6 +81,7 @@ export class MobileBuilder {
     this.copyTargetDir = cfg.copyTargetDir;
     this.copyFileName = cfg.copyFileName;
     this.buildForEmulator = cfg.buildForEmulator;
+    this.tenantAppName = cfg.tenantAppName;
   }
 
   /**
@@ -95,6 +98,7 @@ export class MobileBuilder {
       entryPointType: this.entryPointType,
       serverPath: this.serverURL ? this.serverURL : "http://10.0.2.2:3000", // host localhost of the android emulator
       localUserTables: this.localUserTables,
+      tenantAppName: this.tenantAppName,
     });
     let resultCode = await bundlePackagesAndPlugins(
       this.buildDir,

--- a/packages/saltcorn-mobile-builder/utils/common-build-utils.ts
+++ b/packages/saltcorn-mobile-builder/utils/common-build-utils.ts
@@ -76,14 +76,18 @@ export function writeCfgFile({
   entryPointType,
   serverPath,
   localUserTables,
+  tenantAppName,
 }: any) {
   const wwwDir = join(buildDir, "www");
-  let cfg = {
+  let cfg: any = {
     version_tag: db.connectObj.version_tag,
     entry_point: `get/${entryPointType}/${entryPoint}`,
-    server_path: serverPath,
+    server_path: !serverPath.endsWith("/")
+      ? serverPath
+      : serverPath.substring(serverPath.length - 1),
     localUserTables,
   };
+  if (tenantAppName) cfg.tenantAppName = tenantAppName;
   writeFileSync(join(wwwDir, "config"), JSON.stringify(cfg));
 }
 

--- a/packages/server/app.js
+++ b/packages/server/app.js
@@ -271,6 +271,12 @@ const getApp = async (opts = {}) => {
   passport.deserializeUser(function (user, done) {
     done(null, user);
   });
+  app.use(function (req, res, next) {
+    if (req.headers["x-saltcorn-client"] === "mobile-app") {
+      req.smr = true; // saltcorn-mobile-request
+    }
+    return next();
+  });
   app.use(setTenant);
 
   // Change into s3storage compatible selector
@@ -279,13 +285,6 @@ const getApp = async (opts = {}) => {
   app.use(s3storage.middlewareTransform);
 
   app.use(wrapper(version_tag));
-
-  app.use(function (req, res, next) {
-    if (req.headers["x-saltcorn-client"] === "mobile-app") {
-      req.smr = true; // saltcorn-mobile-request
-    }
-    return next();
-  });
 
   const csurf = csrf();
   if (!opts.disableCsrf)

--- a/packages/server/auth/routes.js
+++ b/packages/server/auth/routes.js
@@ -217,6 +217,7 @@ const loginWithJwt = async (email, password, res) => {
         iss: "saltcorn@saltcorn",
         aud: "saltcorn-mobile-app",
         iat: now.valueOf(),
+        tenant: db.getTenantSchema()
       },
       jwt_secret
     );

--- a/packages/server/auth/routes.js
+++ b/packages/server/auth/routes.js
@@ -199,34 +199,41 @@ const getAuthLinks = (current, noMethods) => {
   return links;
 };
 
-const loginWithJwt = async (email, password, res) => {
-  const user = await User.findOne({ email });
-  if (user && user.checkPassword(password)) {
-    const now = new Date();
-    const jwt_secret = db.connectObj.jwt_secret;
-    const token = jwt.sign(
-      {
-        sub: email,
-        user: {
-          id: user.id,
-          email: user.email,
-          role_id: user.role_id,
-          language: user.language ? user.language : "en",
-          disabled: user.disabled,
+const loginWithJwt = async (email, password, saltcornApp, res) => {
+  const loginFn = async () => {
+    const user = await User.findOne({ email });
+    if (user && user.checkPassword(password)) {
+      const now = new Date();
+      const jwt_secret = db.connectObj.jwt_secret;
+      const token = jwt.sign(
+        {
+          sub: email,
+          user: {
+            id: user.id,
+            email: user.email,
+            role_id: user.role_id,
+            language: user.language ? user.language : "en",
+            disabled: user.disabled,
+          },
+          iss: "saltcorn@saltcorn",
+          aud: "saltcorn-mobile-app",
+          iat: now.valueOf(),
+          tenant: db.getTenantSchema(),
         },
-        iss: "saltcorn@saltcorn",
-        aud: "saltcorn-mobile-app",
-        iat: now.valueOf(),
-        tenant: db.getTenantSchema()
-      },
-      jwt_secret
-    );
-    if (!user.last_mobile_login) await user.updateLastMobileLogin(now);
-    res.json(token);
+        jwt_secret
+      );
+      if (!user.last_mobile_login) await user.updateLastMobileLogin(now);
+      res.json(token);
+    } else {
+      res.json({
+        alerts: [{ type: "danger", msg: "Incorrect user or password" }],
+      });
+    }
+  };
+  if (saltcornApp && saltcornApp !== db.connectObj.default_schema) {
+    await db.runWithTenant(saltcornApp, loginFn);
   } else {
-    res.json({
-      alerts: [{ type: "danger", msg: "Incorrect user or password" }],
-    });
+    await loginFn();
   }
 };
 
@@ -900,7 +907,13 @@ router.post(
       } else {
         const u = await User.create({ email, password });
         await send_verification_email(u, req);
-        if (req.smr) await loginWithJwt(email, password, res);
+        if (req.smr)
+          await loginWithJwt(
+            email,
+            password,
+            req.headers["x-saltcorn-app"],
+            res
+          );
         else signup_login_with_user(u, req, res);
       }
     }
@@ -1009,7 +1022,7 @@ router.get(
     const { method } = req.params;
     if (method === "jwt") {
       const { email, password } = req.query;
-      await loginWithJwt(email, password, res);
+      await loginWithJwt(email, password, req.headers["x-saltcorn-app"], res);
     } else {
       const auth = getState().auth_methods[method];
       if (auth) {

--- a/packages/server/routes/admin.js
+++ b/packages/server/routes/admin.js
@@ -980,7 +980,7 @@ router.post(
     res.attachment(fileName);
     const file = fs.createReadStream(fileName);
     file.on("end", function () {
-      fs.unlink(fileName, function () { });
+      fs.unlink(fileName, function () {});
     });
     file.pipe(res);
   })
@@ -1003,7 +1003,7 @@ router.post(
     );
     if (err) req.flash("error", err);
     else req.flash("success", req.__("Successfully restored backup"));
-    fs.unlink(newPath, function () { });
+    fs.unlink(newPath, function () {});
     res.redirect(`/admin`);
   })
 );
@@ -1547,6 +1547,12 @@ router.post(
     }
     if (appFile) spawnParams.push("-a", appFile);
     if (serverURL) spawnParams.push("-s", serverURL);
+    if (
+      db.is_it_multi_tenant() &&
+      db.getTenantSchema() !== db.connectObj.default_schema
+    ) {
+      spawnParams.push("--tenantAppName", db.getTenantSchema());
+    }
     const child = spawn("saltcorn", spawnParams, {
       stdio: ["ignore", "pipe", "pipe"],
       cwd: ".",

--- a/packages/server/routes/utils.js
+++ b/packages/server/routes/utils.js
@@ -103,8 +103,6 @@ const get_tenant_from_req = (req) => {
   if (req.subdomains && req.subdomains.length > 0)
     return req.subdomains[req.subdomains.length - 1];
 
-  if (req.headers["x-saltcorn-app"])
-    return req.headers["x-saltcorn-app"];
   if (req.subdomains && req.subdomains.length == 0)
     return db.connectObj.default_schema;
   if (!req.subdomains && req.headers.host) {
@@ -115,37 +113,58 @@ const get_tenant_from_req = (req) => {
 };
 
 /**
+ * middleware to extract the tenant domain and call runWithtenant()
  * @param {object} req
  * @param {object} res
  * @param {function} next
  */
 const setTenant = (req, res, next) => {
   if (db.is_it_multi_tenant()) {
-    const other_domain = get_other_domain_tenant(req.hostname);
-    if (other_domain) {
-      const state = getTenant(other_domain);
-      if (!state) {
-        setLanguage(req, res);
-        next();
-      } else {
-        db.runWithTenant(other_domain, () => {
-          setLanguage(req, res, state);
-          state.log(5, `${req.method} ${req.originalUrl}`);
+    // for a saltcorn mobile request use 'req.user.tenant'
+    if (req.smr) {
+      if (
+        req.user?.tenant &&
+        req.user.tenant !== db.connectObj.default_schema
+      ) {
+        const state = getTenant(req.user.tenant);
+        if (!state) {
+          setLanguage(req, res);
           next();
-        });
+        } else {
+          db.runWithTenant(other_domain, () => {
+            setLanguage(req, res, state);
+            state.log(5, `${req.method} ${req.originalUrl}`);
+            next();
+          });
+        }
       }
     } else {
-      const ten = get_tenant_from_req(req);
-      const state = getTenant(ten);
-      if (!state) {
-        setLanguage(req, res);
-        next();
-      } else {
-        db.runWithTenant(ten, () => {
-          setLanguage(req, res, state);
-          state.log(5, `${req.method} ${req.originalUrl}`);
+      const other_domain = get_other_domain_tenant(req.hostname);
+      if (other_domain) {
+        const state = getTenant(other_domain);
+        if (!state) {
+          setLanguage(req, res);
           next();
-        });
+        } else {
+          db.runWithTenant(other_domain, () => {
+            setLanguage(req, res, state);
+            state.log(5, `${req.method} ${req.originalUrl}`);
+            next();
+          });
+        }
+      } else {
+        const ten = get_tenant_from_req(req);
+        const state = getTenant(ten);
+        if (!state) {
+          setLanguage(req, res);
+          next();
+        } else {
+          db.runWithTenant(ten, () => {
+            setLanguage(req, res, state);
+            state.log(5, `${req.method} ${req.originalUrl}`);
+            next();
+          });
+        }
       }
     }
   } else {
@@ -245,5 +264,5 @@ module.exports = {
   getGitRevision,
   getSessionStore,
   setTenant,
-  get_tenant_from_req
+  get_tenant_from_req,
 };

--- a/packages/server/routes/utils.js
+++ b/packages/server/routes/utils.js
@@ -103,6 +103,8 @@ const get_tenant_from_req = (req) => {
   if (req.subdomains && req.subdomains.length > 0)
     return req.subdomains[req.subdomains.length - 1];
 
+  if (req.headers["x-saltcorn-app"])
+    return req.headers["x-saltcorn-app"];
   if (req.subdomains && req.subdomains.length == 0)
     return db.connectObj.default_schema;
   if (!req.subdomains && req.headers.host) {

--- a/packages/server/routes/utils.js
+++ b/packages/server/routes/utils.js
@@ -131,12 +131,16 @@ const setTenant = (req, res, next) => {
           setLanguage(req, res);
           next();
         } else {
-          db.runWithTenant(other_domain, () => {
+          db.runWithTenant(req.user.tenant, () => {
             setLanguage(req, res, state);
             state.log(5, `${req.method} ${req.originalUrl}`);
             next();
           });
         }
+      }
+      else {
+        setLanguage(req, res);
+        next();
       }
     } else {
       const other_domain = get_other_domain_tenant(req.hostname);


### PR DESCRIPTION
- added tenantAppName to the build-app cli to build for a specific tenant
- the mobile app sends the subdomain as a 'x-saltcorn-app' header
- the jwt strategy uses a tenant field of the token