### PR TITLE
fix formatted date not being localised

### DIFF
--- a/packages/saltcorn-data/base-plugin/types.js
+++ b/packages/saltcorn-data/base-plugin/types.js
@@ -1268,8 +1268,15 @@ const date = {
       ],
       run: (d, req, options) => {
         if (!d) return "";
-        if (!options || !options.format) return text(moment(d).format());
-        return text(moment(d).format(options.format));
+        const loc = locale(req);
+        if (loc) {
+          if (!options || !options.format)
+            return text(moment(d).locale(loc).format());
+          return text(moment(d).locale(loc).format(options.format));
+        } else {
+          if (!options || !options.format) return text(moment(d).format());
+          return text(moment(d).format(options.format));
+        }
       },
     },
     /**


### PR DESCRIPTION
Table views showing a date column with the "format" field view were not properly localised, so e.g. week days were always in English. This PR fixes this by applying the locale configuration for this case as well.