### PR TITLE
load cordova plugins via file reference in docker

### DIFF
--- a/packages/saltcorn-mobile-app/package.json
+++ b/packages/saltcorn-mobile-app/package.json
@@ -6,6 +6,7 @@
   "main": "index.js",
   "scripts": {
     "add-platform": "cordova platform add",
+    "add-plugin": "cordova plugin add",
     "build-app": "cordova build "
   },
   "author": "Christian Hugo",
@@ -13,12 +14,7 @@
   "cordova": {
     "platforms": [
       "android"
-    ],
-    "plugins": {
-      "cordova-sqlite-ext": {},
-      "cordova-plugin-file": {},
-      "cordova-plugin-inappbrowser": {}
-    }
+    ]
   },
   "overrides": {
     "ansi-regex": "4.1.1"
@@ -28,8 +24,6 @@
     "cordova-sqlite-ext": "^6.0.0"
   },
   "devDependencies": {
-    "cordova-android": "^10.1.2",
-    "cordova-plugin-file": "^6.0.2",
-    "cordova-plugin-inappbrowser": "^5.0.0"
+    "cordova-android": "^10.1.2"
   }
 }

--- a/packages/saltcorn-mobile-builder/docker/Dockerfile
+++ b/packages/saltcorn-mobile-builder/docker/Dockerfile
@@ -22,6 +22,11 @@ RUN npm install -g cordova
 WORKDIR /init_project
 RUN cordova create project
 WORKDIR /init_project/project
+# download plugins while building
+# so that we can add them later via file reference
+RUN cordova plugin add cordova-sqlite-ext
+RUN cordova plugin add cordova-plugin-file
+RUN cordova plugin add cordova-plugin-inappbrowser
 RUN cordova platform add android
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 ENV ANDROID_SDK_ROOT=/android_sdk

--- a/packages/saltcorn-mobile-builder/docker/entry.bash
+++ b/packages/saltcorn-mobile-builder/docker/entry.bash
@@ -12,6 +12,10 @@ echo "adding android platform"
 npm run add-platform android
 echo "calling cordova clean";
 cordova clean
+echo "adding plugins"
+npm run add-plugin /init_project/project/plugins/cordova-plugin-inappbrowser
+npm run add-plugin /init_project/project/plugins/cordova-plugin-file
+npm run add-plugin /init_project/project/plugins/cordova-sqlite-ext
 echo "calling cordova build";
 cordova build android
 

--- a/packages/saltcorn-mobile-builder/utils/cordova-build-utils.ts
+++ b/packages/saltcorn-mobile-builder/utils/cordova-build-utils.ts
@@ -51,6 +51,7 @@ export function buildApp(
   buildForEmulator?: boolean
 ) {
   if (!useDocker) {
+    addPlugins(buildDir);
     return callBuild(buildDir, platforms, buildForEmulator);
   } else {
     let code = buildApkInContainer(buildDir);
@@ -58,6 +59,38 @@ export function buildApp(
       code = callBuild(buildDir, ["ios"]);
     return code;
   }
+}
+
+/**
+ * call cordova plugin add ...
+ * it loads the dependencies from npm, docker usese cached folders
+ * @param buildDir
+ */
+function addPlugins(buildDir: string) {
+  let result = spawnSync(
+    "npm",
+    ["run", "add-plugin", "--", "cordova-sqlite-ext"],
+    {
+      cwd: buildDir,
+    }
+  );
+  console.log(result.output.toString());
+  result = spawnSync(
+    "npm",
+    ["run", "add-plugin", "--", "cordova-plugin-file"],
+    {
+      cwd: buildDir,
+    }
+  );
+  console.log(result.output.toString());
+  result = spawnSync(
+    "npm",
+    ["run", "add-plugin", "--", "cordova-plugin-inappbrowser"],
+    {
+      cwd: buildDir,
+    }
+  );
+  console.log(result.output.toString());
 }
 
 /**

--- a/packages/server/public/saltcorn.js
+++ b/packages/server/public/saltcorn.js
@@ -505,7 +505,7 @@ function poll_mobile_build_finished(outDirName, pollCount, orginalBtnHtml) {
     data: { build_dir: outDirName },
     success: function (res) {
       if (!res.finished) {
-        if (pollCount >= 40) {
+        if (pollCount >= 50) {
           removeSpinner("buildMobileAppBtnId", orginalBtnHtml);
           notifyAlert({
             type: "danger",


### PR DESCRIPTION
- removed cordova plugins from package.json and add them at build time
- a build without docker adds them the normal way and they are loaded from npm
- a docker build uses plugins that are already on disk
