### PR TITLE
Allow UUID in run_action route

### DIFF
--- a/packages/saltcorn-data/base-plugin/viewtemplates/viewable_fields.js
+++ b/packages/saltcorn-data/base-plugin/viewtemplates/viewable_fields.js
@@ -58,8 +58,8 @@ const action_url = (
   }
   const confirmStr = confirm ? `if(confirm('${"Are you sure?"}'))` : "";
   return {
-    javascript: `${confirmStr}view_post('${viewname}', 'run_action', {${colIdNm}:'${colId}', id:${r?.id
-      }${columnIndex(colIndex)}});`,
+    javascript: `${confirmStr}view_post('${viewname}', 'run_action', {${colIdNm}:'${colId}', id:'${r?.id
+      }${columnIndex(colIndex)}'});`,
   };
 };
 


### PR DESCRIPTION
By writing the ID in single quotes UUIDs can be used. 