### PR TITLE
Set browser locale as active if user.language is not set yet

### DIFF
--- a/packages/server/auth/routes.js
+++ b/packages/server/auth/routes.js
@@ -1158,7 +1158,7 @@ const setLanguageForm = (req, user) =>
         option(
           {
             value: locale,
-            ...(user && user.language === locale && { selected: true }),
+            ...(((user && user.language === locale) || (user && !user.language && req.getLocale() === locale)) && { selected: true }),
           },
           language
         )


### PR DESCRIPTION
Set browser locale as active if user.language is not set yet. Otherwise, the default selection will always be English in the dropdown menu. As the form is saved on changes only, a user with a browser locale different than English has to select a different language first, before he can select and save English as language. This is quite inconvenient.