### PR TITLE
public login on mobile, set cfg with multitenant

### DIFF
--- a/packages/saltcorn-cli/src/commands/set-cfg.js
+++ b/packages/saltcorn-cli/src/commands/set-cfg.js
@@ -4,7 +4,7 @@
  */
 const { Command, flags } = require("@oclif/command");
 const { cli } = require("cli-ux");
-const { maybe_as_tenant, parseJSONorString } = require("../common");
+const { maybe_as_tenant, init_some_tenants, parseJSONorString } = require("../common");
 const fs = require("fs");
 /**
  * SetCfgCommand Class
@@ -29,7 +29,8 @@ class SetCfgCommand extends Command {
       : flags.file
       ? fs.readFileSync(flags.file, "utf-8")
       : args.value;
-
+    if(flags.tenant)
+      await init_some_tenants(flags.tenant);
     await maybe_as_tenant(flags.tenant, async () => {
       if (flags.plugin) {
         const Plugin = require("@saltcorn/data/models/plugin");

--- a/packages/saltcorn-mobile-app/www/js/utils/global_utils.js
+++ b/packages/saltcorn-mobile-app/www/js/utils/global_utils.js
@@ -1,4 +1,4 @@
-const routingHistory = [];
+let routingHistory = [];
 
 function currentLocation() {
   if (routingHistory.length == 0) return undefined;
@@ -178,6 +178,10 @@ async function goBack(steps = 1, exitOnFirstPage = false) {
     await handleRoute("/");
   } else {
     routingHistory = routingHistory.slice(0, routingHistory.length - steps);
+    // don't repeat a post
+    if (routingHistory[routingHistory.length - 1].route.startsWith("post/")) {
+      routingHistory.pop();
+    }
     const newCurrent = routingHistory.pop();
     await handleRoute(newCurrent.route, newCurrent.query);
   }


### PR DESCRIPTION
- use a jwt with roleid 10 for logins without email and password
- otherwise in multitenant mode, we land on the root app as public user
- init the tenant in 'set-cfg cli' if the parameter is set