### PR TITLE
docker image with saltcorn and mobile dependencies

### DIFF
--- a/Dockerfile.mobile.release
+++ b/Dockerfile.mobile.release
@@ -1,0 +1,51 @@
+FROM node:16
+
+RUN apt update && apt install -y wget unzip \
+  openjdk-11-jdk openjdk-11-demo openjdk-11-doc openjdk-11-jre-headless openjdk-11-source 
+
+# install android commandline tools and sdk
+RUN wget https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip
+RUN unzip commandlinetools-linux-8512546_latest.zip
+RUN mkdir android_sdk
+RUN yes | cmdline-tools/bin/sdkmanager --sdk_root=android_sdk --install "cmdline-tools;latest"
+RUN android_sdk/cmdline-tools/latest/bin/sdkmanager --list
+RUN android_sdk/cmdline-tools/latest/bin/sdkmanager "platforms;android-11"
+RUN android_sdk/cmdline-tools/latest/bin/sdkmanager "build-tools;30.0.3"
+
+# download gradle
+RUN wget -q https://services.gradle.org/distributions/gradle-7.1.1-all.zip \
+    && unzip gradle-7.1.1-all.zip -d /opt
+
+RUN npm install -g cordova
+
+# create an empty project, the first init seems to take longer
+WORKDIR /init_project
+RUN cordova create project
+WORKDIR /init_project/project
+# download plugins while building
+# so that we can add them later via file reference
+RUN cordova plugin add cordova-sqlite-ext
+RUN cordova plugin add cordova-plugin-file
+RUN cordova plugin add cordova-plugin-inappbrowser
+RUN cordova platform add android
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+ENV ANDROID_SDK_ROOT=/android_sdk
+ENV GRADLE_HOME=/opt/gradle-7.1.1
+ENV PATH=$PATH:/opt/gradle-7.1.1/bin
+# stop gradle from downloading itself
+ENV CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL=file\:/gradle-7.1.1-all.zip
+RUN cordova build android
+
+# due to a bug in npm that has been addressed since then
+# some files in '/root/.npm' are owned by root
+RUN chown -R 1000:1000 "/root/.npm"
+RUN chmod -R o+rwx "/root/.npm"
+
+
+# taken from Dockerfile.release
+ENV NODE_ENV "production"
+ENV SALTCORN_DISABLE_UPGRADE "true"
+
+RUN npm install -g @saltcorn/cli@0.8.0-beta.4 --unsafe
+
+ENTRYPOINT ["/usr/local/bin/saltcorn"]

--- a/deploy/docker_build_push.sh
+++ b/deploy/docker_build_push.sh
@@ -9,6 +9,10 @@ docker build -t saltcorn/saltcorn:latest -f Dockerfile.release .
 docker push saltcorn/saltcorn:latest
 docker build -t saltcorn/saltcorn:$VERSION -f Dockerfile.release .
 docker push saltcorn/saltcorn:$VERSION
+docker build -t saltcorn/saltcorn-with-mobile:latest -f Dockerfile.mobile.release .
+docker push saltcorn/saltcorn-with-mobile:latest
+docker build -t saltcorn/saltcorn-with-mobile:$VERSION -f Dockerfile.mobile.release .
+docker push saltcorn/saltcorn-with-mobile:$VERSION
 docker build -t saltcorn/saltcorn:dev -f Dockerfile.dev .
 docker push saltcorn/saltcorn:dev
 docker build -t saltcorn/saltcorn:pyml -f Dockerfile.pyml .

--- a/packages/saltcorn-cli/src/commands/release.js
+++ b/packages/saltcorn-cli/src/commands/release.js
@@ -127,6 +127,11 @@ class ReleaseCommand extends Command {
       `Dockerfile.release`,
       dockerfile.replace(/cli\@.* --unsafe/, `cli@${version} --unsafe`)
     );
+    const dockerfileWithMobile = fs.readFileSync(`Dockerfile.mobile.release`, "utf8");
+    fs.writeFileSync(
+      `Dockerfile.mobile.release`,
+      dockerfileWithMobile.replace(/cli\@.* --unsafe/, `cli@${version} --unsafe`)
+    );
     //git commit tag and push
     spawnSync("git", ["commit", "-am", "v" + version], {
       stdio: "inherit",

--- a/packages/saltcorn-cli/src/commands/release.js
+++ b/packages/saltcorn-cli/src/commands/release.js
@@ -130,7 +130,7 @@ class ReleaseCommand extends Command {
     const dockerfileWithMobile = fs.readFileSync(`Dockerfile.mobile.release`, "utf8");
     fs.writeFileSync(
       `Dockerfile.mobile.release`,
-      dockerfileWithMobile.replace(/cli\@.* --unsafe/, `cli@${version} --unsafe`)
+      dockerfileWithMobile.replace(/cli@.* --unsafe/, `cli@${version} --unsafe`)
     );
     //git commit tag and push
     spawnSync("git", ["commit", "-am", "v" + version], {

--- a/packages/saltcorn-cli/src/commands/setup.js
+++ b/packages/saltcorn-cli/src/commands/setup.js
@@ -83,7 +83,7 @@ const unloadModule = (mod) => {
  */
 const setupDevMode = async () => {
   const dbPath = path.join(defaultDataPath, "scdb.sqlite");
-  fs.promises.mkdir(defaultDataPath, { recursive: true });
+  await fs.promises.mkdir(defaultDataPath, { recursive: true });
   const session_secret = gen_password();
   const jwt_secret = genJwtSecret();
   await write_connection_config({
@@ -286,7 +286,7 @@ const setup_connection_config = async () => {
  * @returns {Promise<void>}
  */
 const write_connection_config = async (connobj) => {
-  fs.promises.mkdir(configFileDir, { recursive: true });
+  await fs.promises.mkdir(configFileDir, { recursive: true });
   fs.writeFileSync(configFilePath, JSON.stringify(connobj), { mode: 0o600 });
 };
 

--- a/packages/saltcorn-mobile-builder/utils/cordova-build-utils.ts
+++ b/packages/saltcorn-mobile-builder/utils/cordova-build-utils.ts
@@ -74,6 +74,10 @@ function addPlugins(buildDir: string) {
     ["run", "add-plugin", "--", "cordova-sqlite-ext"],
     {
       cwd: buildDir,
+      env: {
+        ...process.env,
+        NODE_ENV: "development",
+      },
     }
   );
   console.log(result.output.toString());
@@ -82,6 +86,10 @@ function addPlugins(buildDir: string) {
     ["run", "add-plugin", "--", "cordova-plugin-file"],
     {
       cwd: buildDir,
+      env: {
+        ...process.env,
+        NODE_ENV: "development",
+      },
     }
   );
   console.log(result.output.toString());
@@ -90,6 +98,10 @@ function addPlugins(buildDir: string) {
     ["run", "add-plugin", "--", "cordova-plugin-inappbrowser"],
     {
       cwd: buildDir,
+      env: {
+        ...process.env,
+        NODE_ENV: "development",
+      },
     }
   );
   console.log(result.output.toString());
@@ -103,6 +115,10 @@ function addPlugins(buildDir: string) {
 export function addPlatforms(buildDir: string, platforms: string[]) {
   const result = spawnSync("npm", ["run", "add-platform", "--", ...platforms], {
     cwd: buildDir,
+    env: {
+      ...process.env,
+      NODE_ENV: "development",
+    },
   });
   console.log(result.output.toString());
 }

--- a/packages/server/routes/admin.js
+++ b/packages/server/routes/admin.js
@@ -1657,11 +1657,11 @@ router.post(
     const childOutputs = [];
     child.stdout.on("data", (data) => {
       // console.log(data.toString());
-      childOutputs.push(data.toString());
+      if (data) childOutputs.push(data.toString());
     });
     child.stderr.on("data", (data) => {
       // console.log(data.toString());
-      childOutputs.push(data.toString());
+      childOutputs.push(data ? data.toString() : req.__("An error occurred"));
     });
     child.on("exit", async function (exitCode, signal) {
       const logFile = exitCode === 0 ? "logs.txt" : "error_logs.txt";


### PR DESCRIPTION
- the image has all depencies to build a mobile app for android and the '@saltcorn/cli' version from npm (like the release image)
- is needed because the image from 'saltcorn-mobile-builder' only has the build dependencies and it's complicated to run the build image from another container
- added NODE_ENV=development for the cordova commands it fails with NODE_ENV=production