### PR TITLE
Config: increase default upload size. log client errors option

### DIFF
--- a/packages/saltcorn-data/models/config.ts
+++ b/packages/saltcorn-data/models/config.ts
@@ -237,6 +237,14 @@ const configTypes: ConfigTypes = {
     blurb: "Print all SQL statements to the standard output",
   },
   /** @type {object} */
+  log_client_errors: {
+    type: "Bool",
+    label: "Log client errors",
+    default: false,
+    root_only: true,
+    blurb: "Record all client errors in the crash log",
+  },
+  /** @type {object} */
   multitenancy_enabled: {
     type: "Bool",
     root_only: true,

--- a/packages/saltcorn-data/models/config.ts
+++ b/packages/saltcorn-data/models/config.ts
@@ -639,9 +639,9 @@ const configTypes: ConfigTypes = {
   /** @type {object} */
   file_upload_limit: {
     type: "Integer",
-    label: "File upload size limit in bytes",
-    default: 1024 * 1024 * 512,
-    blurb: "Defines in bytes limit for upload files in express-fileupload.",
+    label: "Upload size limit (Mb)",
+    default: 512,
+    blurb: "Maximum upload file size in Megabytes",
   },
 };
 // TODO move list of languages from code to configuration

--- a/packages/saltcorn-data/models/config.ts
+++ b/packages/saltcorn-data/models/config.ts
@@ -647,9 +647,8 @@ const configTypes: ConfigTypes = {
   /** @type {object} */
   file_upload_limit: {
     type: "Integer",
-    label: "Upload size limit (Mb)",
-    default: 512,
-    blurb: "Maximum upload file size in Megabytes",
+    label: "Upload size limit (Kb)",
+    blurb: "Maximum upload file size in kilobytes",
   },
 };
 // TODO move list of languages from code to configuration

--- a/packages/saltcorn-data/models/config.ts
+++ b/packages/saltcorn-data/models/config.ts
@@ -633,7 +633,7 @@ const configTypes: ConfigTypes = {
     label: "File upload timeout",
     default: 0,
     blurb:
-      "Defines how long to wait for data before aborting for express-fileupload. " +
+      "Defines how long to wait for data before aborting file upload. " +
       "Set to 0 if you want to turn off timeout checks. ",
   },
   /** @type {object} */

--- a/packages/saltcorn-data/models/config.ts
+++ b/packages/saltcorn-data/models/config.ts
@@ -640,7 +640,7 @@ const configTypes: ConfigTypes = {
   file_upload_limit: {
     type: "Integer",
     label: "File upload size limit in bytes",
-    default: 1024 * 1024 * 10,
+    default: 1024 * 1024 * 512,
     blurb: "Defines in bytes limit for upload files in express-fileupload.",
   },
 };

--- a/packages/saltcorn-markup/builder.ts
+++ b/packages/saltcorn-markup/builder.ts
@@ -108,9 +108,8 @@ export = /**
       "${encode(layout || {})}",
       ${JSON.stringify(mode)}
     );
-    document.addEventListener('DOMContentLoaded',
-      function(){window.onerror=globalErrorCatcher},false);
-    ;`),
+    enable_error_catcher();
+    `),
     script(
       domReady(`window.set_state_fields = ()=>{};
       window.set_state_field = ()=>{};

--- a/packages/server/locales/en.json
+++ b/packages/server/locales/en.json
@@ -1057,5 +1057,7 @@
 	"Specifies a default filter for what file types the user can pick from the file input dialog box. Example is `.doc, text/csv,audio/*,video/*,image/*`": "Specifies a default filter for what file types the user can pick from the file input dialog box. Example is `.doc, text/csv,audio/*,video/*,image/*`",
 	"Destination page": "Destination page",
 	"Module Store endpoint": "Module Store endpoint",
-	"Authentication settings updated": "Authentication settings updated"
+	"Authentication settings updated": "Authentication settings updated",
+	"Log client errors": "Log client errors",
+	"Record all client errors in the crash log": "Record all client errors in the crash log"
 }

--- a/packages/server/locales/en.json
+++ b/packages/server/locales/en.json
@@ -1059,5 +1059,13 @@
 	"Module Store endpoint": "Module Store endpoint",
 	"Authentication settings updated": "Authentication settings updated",
 	"Log client errors": "Log client errors",
-	"Record all client errors in the crash log": "Record all client errors in the crash log"
+	"Record all client errors in the crash log": "Record all client errors in the crash log",
+	"Default File accept filter": "Default File accept filter",
+	"File upload debug": "File upload debug",
+	"Turn on to debug file upload in express-fileupload.": "Turn on to debug file upload in express-fileupload.",
+	"Upload size limit (Kb)": "Upload size limit (Kb)",
+	"Maximum upload file size in kilobytes": "Maximum upload file size in kilobytes",
+	"File upload timeout": "File upload timeout",
+	"Defines how long to wait for data before aborting file upload. Set to 0 if you want to turn off timeout checks. ": "Defines how long to wait for data before aborting file upload. Set to 0 if you want to turn off timeout checks. ",
+	"Files settings": "Files settings"
 }

--- a/packages/server/locales/fr.json
+++ b/packages/server/locales/fr.json
@@ -274,5 +274,17 @@
 	"Field %s deleted": "Champ %s supprimé",
 	"Language: ": "Langage: ",
 	"Local": "Local",
-	"Language changed to %s": "Langage changé vers %s"
+	"Language changed to %s": "Langage changé vers %s",
+	"CSV upload": "CSV upload",
+	"Create page": "Create page",
+	"Action": "Action",
+	"Table or Channel": "Table or Channel",
+	"Add trigger": "Add trigger",
+	"Upload file(s)": "Upload file(s)",
+	"About application": "About application",
+	"Modules": "Modules",
+	"Users and security": "Users and security",
+	"Site structure": "Site structure",
+	"Events": "Events",
+	"Are you sure?": "Are you sure?"
 }

--- a/packages/server/public/saltcorn.js
+++ b/packages/server/public/saltcorn.js
@@ -202,7 +202,21 @@ function view_post(viewname, route, data, onDone) {
     });
 }
 let logged_errors = [];
+let error_catcher_enabled = false;
+function enable_error_catcher() {
+  if (error_catcher_enabled) return;
+  document.addEventListener(
+    "DOMContentLoaded",
+    function () {
+      window.onerror = globalErrorCatcher;
+    },
+    false
+  );
+  error_catcher_enabled = true;
+}
+
 function globalErrorCatcher(message, source, lineno, colno, error) {
+  console.log("global error catcher!");
   if (error && error.preventDefault) error.preventDefault();
   if (logged_errors.includes(message)) return;
   logged_errors.push(message);
@@ -267,9 +281,9 @@ function ajax_modal(url, opts = {}) {
       $("#scmodal").prop("data-modal-state", url);
       new bootstrap.Modal($("#scmodal")).show();
       initialize_page();
-      (opts.onOpen || function () { })(res);
+      (opts.onOpen || function () {})(res);
       $("#scmodal").on("hidden.bs.modal", function (e) {
-        (opts.onClose || function () { })(res);
+        (opts.onClose || function () {})(res);
         $("body").css("overflow", "");
       });
     },
@@ -278,7 +292,7 @@ function ajax_modal(url, opts = {}) {
 
 function saveAndContinue(e, k) {
   var form = $(e).closest("form");
-  const valres = form[0].reportValidity()
+  const valres = form[0].reportValidity();
   if (!valres) return;
   submitWithEmptyAction(form[0]);
   var url = form.attr("action");
@@ -323,7 +337,7 @@ function applyViewConfig(e, url, k) {
       "CSRF-Token": _sc_globalCsrf,
     },
     data: JSON.stringify(cfg),
-    error: function (request) { },
+    error: function (request) {},
     success: function (res) {
       k && k(res);
       !k && updateViewPreview();
@@ -344,7 +358,7 @@ function updateViewPreview() {
         "CSRF-Token": _sc_globalCsrf,
       },
 
-      error: function (request) { },
+      error: function (request) {},
       success: function (res) {
         $preview.css({ opacity: 1.0 });
 
@@ -359,9 +373,8 @@ function updateViewPreview() {
         $preview.find("input").attr("readonly", true);
 
         //disable functions preview migght try to call
-        set_state_field = () => { }
-        set_state_fields = () => { }
-
+        set_state_field = () => {};
+        set_state_fields = () => {};
       },
     });
   }
@@ -596,15 +609,13 @@ function build_mobile_app(button) {
       localStorage.setItem("sidebarClosed", `${closed}`);
     });
   }
-})()
-
-
+})() +
   /*
   https://github.com/jeffdavidgreen/bootstrap-html5-history-tabs/blob/master/bootstrap-history-tabs.js
   Copyright (c) 2015 Jeff Green
   */
 
-  + (function ($) {
+  (function ($) {
     "use strict";
     $.fn.historyTabs = function () {
       var that = this;
@@ -619,21 +630,24 @@ function build_mobile_app(button) {
         $(element).on("show.bs.tab", function () {
           var stateObject = { url: $(this).attr("href") };
 
-          if (window.location.hash && stateObject.url !== window.location.hash) {
+          if (
+            window.location.hash &&
+            stateObject.url !== window.location.hash
+          ) {
             window.history.pushState(
               stateObject,
               document.title,
               window.location.pathname +
-              window.location.search +
-              $(this).attr("href")
+                window.location.search +
+                $(this).attr("href")
             );
           } else {
             window.history.replaceState(
               stateObject,
               document.title,
               window.location.pathname +
-              window.location.search +
-              $(this).attr("href")
+                window.location.search +
+                $(this).attr("href")
             );
           }
         });
@@ -649,4 +663,33 @@ function build_mobile_app(button) {
 
 // Copyright (c) 2011 Marcus Ekwall, http://writeless.se/
 // https://github.com/mekwall/jquery-throttle
-(function (a) { var b = a.jQuery || a.me || (a.me = {}), i = function (e, f, g, h, c, a) { f || (f = 100); var d = !1, j = !1, i = typeof g === "function", l = function (a, b) { d = setTimeout(function () { d = !1; if (h || c) e.apply(a, b), c && (j = +new Date); i && g.apply(a, b) }, f) }, k = function () { if (!d || a) { if (!d && !h && (!c || +new Date - j > f)) e.apply(this, arguments), c && (j = +new Date); (a || !c) && clearTimeout(d); l(this, arguments) } }; if (b.guid) k.guid = e.guid = e.guid || b.guid++; return k }; b.throttle = i; b.debounce = function (a, b, g, h, c) { return i(a, b, g, h, c, !0) } })(this);
+(function (a) {
+  var b = a.jQuery || a.me || (a.me = {}),
+    i = function (e, f, g, h, c, a) {
+      f || (f = 100);
+      var d = !1,
+        j = !1,
+        i = typeof g === "function",
+        l = function (a, b) {
+          d = setTimeout(function () {
+            d = !1;
+            if (h || c) e.apply(a, b), c && (j = +new Date());
+            i && g.apply(a, b);
+          }, f);
+        },
+        k = function () {
+          if (!d || a) {
+            if (!d && !h && (!c || +new Date() - j > f))
+              e.apply(this, arguments), c && (j = +new Date());
+            (a || !c) && clearTimeout(d);
+            l(this, arguments);
+          }
+        };
+      if (b.guid) k.guid = e.guid = e.guid || b.guid++;
+      return k;
+    };
+  b.throttle = i;
+  b.debounce = function (a, b, g, h, c) {
+    return i(a, b, g, h, c, !0);
+  };
+})(this);

--- a/packages/server/public/saltcorn.js
+++ b/packages/server/public/saltcorn.js
@@ -216,7 +216,6 @@ function enable_error_catcher() {
 }
 
 function globalErrorCatcher(message, source, lineno, colno, error) {
-  console.log("global error catcher!");
   if (error && error.preventDefault) error.preventDefault();
   if (logged_errors.includes(message)) return;
   logged_errors.push(message);

--- a/packages/server/routes/admin.js
+++ b/packages/server/routes/admin.js
@@ -1822,7 +1822,12 @@ router.post(
 const dev_form = async (req) => {
   return await config_fields_form({
     req,
-    field_names: ["development_mode", "log_sql", "log_level"],
+    field_names: [
+      "development_mode",
+      "log_sql",
+      "log_client_errors",
+      "log_level",
+    ],
     action: "/admin/dev",
   });
 };

--- a/packages/server/routes/tenant.js
+++ b/packages/server/routes/tenant.js
@@ -21,6 +21,7 @@ const {
   renderForm,
   link,
   post_delete_btn,
+  localeDateTime,
   mkTable,
 } = require("@saltcorn/markup");
 const {
@@ -384,7 +385,7 @@ router.get(
               },
               {
                 label: req.__("Created"),
-                key: (r) => text(r.created),
+                key: (r) => localeDateTime(r.created),
               },
               {
                 label: req.__("Information"),

--- a/packages/server/s3storage.js
+++ b/packages/server/s3storage.js
@@ -47,7 +47,7 @@ module.exports = {
     } else {
       // Use regular file upload https://www.npmjs.com/package/express-fileupload
       const fileSizeLimit =
-        1024 * 1024 * +getState().getConfig("file_upload_limit", 0);
+        1024 * +getState().getConfig("file_upload_limit", 0);
       fileUpload({
         useTempFiles: true,
         createParentPath: true,
@@ -59,9 +59,11 @@ module.exports = {
         defCharset: "utf8",
         defParamCharset: "utf8",
         // 0 - means no upload limit check
-        limits: {
-          fileSize: fileSizeLimit,
-        },
+        limits: fileSizeLimit
+          ? {
+              fileSize: fileSizeLimit,
+            }
+          : {},
         abortOnLimit: fileSizeLimit !== 0,
         // 0 - means no upload limit check
         uploadTimeout: getState().getConfig("file_upload_timeout", 0),

--- a/packages/server/s3storage.js
+++ b/packages/server/s3storage.js
@@ -46,7 +46,8 @@ module.exports = {
       s3upload(req, res, next);
     } else {
       // Use regular file upload https://www.npmjs.com/package/express-fileupload
-      const fileSizeLimit = getState().getConfig("file_upload_limit", 0);
+      const fileSizeLimit =
+        1024 * 1024 * +getState().getConfig("file_upload_limit", 0);
       fileUpload({
         useTempFiles: true,
         createParentPath: true,

--- a/packages/server/wrapper.js
+++ b/packages/server/wrapper.js
@@ -203,6 +203,8 @@ const get_headers = (req, version_tag, description, extras = []) => {
     from_cfg.push({ style: state.getConfig("page_custom_css", "") });
   if (state.getConfig("page_custom_html", ""))
     from_cfg.push({ headerTag: state.getConfig("page_custom_html", "") });
+  if (state.getConfig("log_client_errors", false))
+    from_cfg.push({ scriptBody: `enable_error_catcher()` });
   const state_headers = [];
   for (const hs of Object.values(state.headers)) {
     state_headers.push(...hs);


### PR DESCRIPTION
This removes the default file upload limit, because that limit is imposed on the initial upload of a backup to restore. File size limit is still available as an option (change base to kb)