### PR TITLE
don't fail for source-map-support

### DIFF
--- a/packages/saltcorn-cli/bin/saltcorn
+++ b/packages/saltcorn-cli/bin/saltcorn
@@ -1,8 +1,16 @@
 #!/usr/bin/env node
 
-require("source-map-support").install({
-  handleUncaughtExceptions: false,
-});
+try {
+  require("source-map-support").install({
+    handleUncaughtExceptions: false,
+  });
+} catch (error) {
+  console.log(
+    "Warning: Unable to init the 'source-map-support' module. " +
+      "I will run without it."
+  );
+  console.log("Stack traces of source-mapped files won't be formatted.");
+}
 
 require("@oclif/command")
   .run()


### PR DESCRIPTION
- inform the user but don't crash
- stack traces in TypeScript modules will point into the dist folder when the init fails