### PR TITLE
vagrant test and cli command to build the cordova-builder

### DIFF
--- a/deploy/vagrant-test-install/ubuntu2004-mobile-docker/Vagrantfile
+++ b/deploy/vagrant-test-install/ubuntu2004-mobile-docker/Vagrantfile
@@ -1,0 +1,109 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+    # The most common configuration options are documented and commented below.
+    # For a complete reference, please see the online documentation at
+    # https://docs.vagrantup.com.
+  
+    # Every Vagrant development environment requires a box. You can search for
+    # boxes at https://vagrantcloud.com/search.
+    config.vm.box = "ubuntu/focal64"
+  
+    config.ssh.forward_agent = true
+  
+    config.ssh.insert_key = false
+  
+    # Disable automatic box update checking. If you disable this, then
+    # boxes will only be checked for updates when the user runs
+    # `vagrant box outdated`. This is not recommended.
+    # config.vm.box_check_update = false
+  
+    # Create a forwarded port mapping which allows access to a specific port
+    # within the machine from a port on the host machine. In the example below,
+    # accessing "localhost:8080" will access port 80 on the guest machine.
+    # NOTE: This will enable public access to the opened port
+    # config.vm.network "forwarded_port", guest: 80, host: 8080
+  
+    # Create a forwarded port mapping which allows access to a specific port
+    # within the machine from a port on the host machine and only allow access
+    # via 127.0.0.1 to disable public access
+    # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+  
+    # Create a private network, which allows host-only access to the machine
+    # using a specific IP.
+    # config.vm.network "private_network", ip: "192.168.33.10"
+  
+    # Create a public network, which generally matched to bridged network.
+    # Bridged networks make the machine appear as another physical device on
+    # your network.
+    # config.vm.network "public_network"
+  
+    # Share an additional folder to the guest VM. The first argument is
+    # the path on the host to the actual folder. The second argument is
+    # the path on the guest to mount the folder. And the optional third
+    # argument is a set of non-required options.
+    # config.vm.synced_folder "../data", "/vagrant_data"
+  
+    # Provider-specific configuration so you can fine-tune various
+    # backing providers for Vagrant. These expose provider-specific options.
+    # Example for VirtualBox:
+    #
+    # config.vm.provider "virtualbox" do |vb|
+    #   # Display the VirtualBox GUI when booting the machine
+    #   vb.gui = true
+    #
+    #   # Customize the amount of memory on the VM:
+    #   vb.memory = "1024"
+    # end
+    #
+    # View the documentation for the provider you are using for more
+    # information on available options.
+  
+    config.vm.provider "virtualbox" do |vb|  
+      # Customize the amount of memory on the VM:
+      vb.memory = "4096"
+    end
+  
+  
+    # Enable provisioning with a shell script. Additional provisioners such as
+    # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+    # documentation for more information about their specific syntax and use.
+    config.vm.provision "shell", inline: <<-SHELL
+      wget -qO - https://deb.nodesource.com/setup_16.x | bash -
+      apt-get install -qqy nodejs
+      sudo -iu vagrant npx -y saltcorn-install -s -y
+
+      # install docker
+      sudo -y apt-get update
+      sudo -y apt-get install \
+         ca-certificates \
+         curl \
+         gnupg \
+         lsb-release
+      sudo mkdir -p /etc/apt/keyrings
+      curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+      echo \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+        $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+      sudo apt-get -y update
+      sudo apt-get -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+
+      # add user saltcorn to docker group 
+      # and build the cordova-builder image
+      sudo groupadd docker
+      sudo usermod -aG docker saltcorn
+      sudo -u saltcorn docker build /home/saltcorn/.local/lib/node_modules/@saltcorn/cli/node_modules/@saltcorn/mobile-builder/docker \
+        --network host -f /home/saltcorn/.local/lib/node_modules/@saltcorn/cli/node_modules/@saltcorn/mobile-builder/docker/Dockerfile \
+        -t saltcorn/cordova-builder
+      
+      cd /home/saltcorn
+      sudo -u saltcorn /home/saltcorn/.local/bin/saltcorn install-pack -n "Address book"
+      sudo -u saltcorn /home/saltcorn/.local/bin/saltcorn build-app -p "android" -s "http://10.0.2.2" -b "/home/saltcorn/build_dir" -e "EditPerson" -d
+    SHELL
+  end
+  

--- a/deploy/vagrant-test-install/ubuntu2004-mobile-docker/Vagrantfile
+++ b/deploy/vagrant-test-install/ubuntu2004-mobile-docker/Vagrantfile
@@ -97,10 +97,8 @@ Vagrant.configure("2") do |config|
       # and build the cordova-builder image
       sudo groupadd docker
       sudo usermod -aG docker saltcorn
-      sudo -u saltcorn docker build /home/saltcorn/.local/lib/node_modules/@saltcorn/cli/node_modules/@saltcorn/mobile-builder/docker \
-        --network host -f /home/saltcorn/.local/lib/node_modules/@saltcorn/cli/node_modules/@saltcorn/mobile-builder/docker/Dockerfile \
-        -t saltcorn/cordova-builder
-      
+      sudo -u saltcorn /home/saltcorn/.local/bin/saltcorn build-cordova-builder
+
       cd /home/saltcorn
       sudo -u saltcorn /home/saltcorn/.local/bin/saltcorn install-pack -n "Address book"
       sudo -u saltcorn /home/saltcorn/.local/bin/saltcorn build-app -p "android" -s "http://10.0.2.2" -b "/home/saltcorn/build_dir" -e "EditPerson" -d

--- a/packages/saltcorn-cli/src/commands/build-app.js
+++ b/packages/saltcorn-cli/src/commands/build-app.js
@@ -90,7 +90,7 @@ class BuildAppCommand extends Command {
   }
 }
 
-BuildAppCommand.description = "build mobile app";
+BuildAppCommand.description = "Build mobile app";
 
 BuildAppCommand.flags = {
   tenantAppName: flags.string({

--- a/packages/saltcorn-cli/src/commands/build-cordova-builder.js
+++ b/packages/saltcorn-cli/src/commands/build-cordova-builder.js
@@ -1,0 +1,44 @@
+const { Command } = require("@oclif/command");
+const { join } = require("path");
+const { spawnSync } = require("child_process");
+
+/**
+ * This is a oclif command to build the 'saltcorn/cordova-builder' docker image.
+ * The image is used in the 'build-app' command to run the cordova commands.
+ * Please make sure docker is callable without sudo (see rootless mode, or add the user to the docker group).
+ */
+class BuildCordovaBuilder extends Command {
+  run() {
+    const dockerDir = join(
+      require.resolve("@saltcorn/mobile-builder"),
+      "..",
+      "..",
+      "docker"
+    );
+    const result = spawnSync(
+      "docker",
+      [
+        "build",
+        dockerDir,
+        "--network",
+        "host",
+        "-f",
+        join(dockerDir, "Dockerfile"),
+        "-t",
+        "saltcorn/cordova-builder",
+      ],
+      { cwd: ".", stdio: "inherit" }
+    );
+    if (result.error) console.log(result.error.toString());
+  }
+}
+
+BuildCordovaBuilder.description =
+  "Build the 'saltcorn/cordova-builder' docker image";
+
+BuildCordovaBuilder.help =
+  "Build the 'saltcorn/cordova-builder' docker image. " +
+  "This image is used in the 'build-app' command to run the cordova commands. " +
+  "Please make sure docker is callable without using root (see rootless mode, or add the user to the docker group).";
+
+module.exports = BuildCordovaBuilder;

--- a/packages/saltcorn-mobile-builder/utils/cordova-build-utils.ts
+++ b/packages/saltcorn-mobile-builder/utils/cordova-build-utils.ts
@@ -39,7 +39,9 @@ export function buildApkInContainer(buildDir: string) {
     ],
     { cwd: "." }
   );
-  console.log(result.output.toString());
+  if (result.output) console.log(result.output.toString());
+  else if (result.error) console.log(result.error.toString());
+  else console.log("docker finished without output");
   return result.status;
 }
 


### PR DESCRIPTION
- added a vagrant file that installs docker, adds saltcorn to the docker group and builds a mobile app with the saltcorn/cordova-builder docker image
- Normally, 'cordova-builder' is created while installing saltcorn but it failed because the new saltcorn user wasn't allowed to access docker
- as a workaround, the vagrant file re-builds the image manually