### PR TITLE
init mobile cfg in view queries

### DIFF
--- a/packages/saltcorn-data/tests/remote_query_helper.ts
+++ b/packages/saltcorn-data/tests/remote_query_helper.ts
@@ -2,6 +2,7 @@ import db from "../db";
 import { sign } from "jsonwebtoken";
 import axios from "axios";
 import User from "../models/user";
+const State = require("../db/state");
 
 declare let global: any;
 
@@ -27,6 +28,8 @@ export const prepareQueryEnviroment = async () => {
       },
     },
   };
+  const state = await State.getState();
+  state.mobileConfig = { jwt: token };
 };
 
 export const sendViewToServer = async (view: any) => {

--- a/packages/saltcorn-data/tests/remote_query_helper.ts
+++ b/packages/saltcorn-data/tests/remote_query_helper.ts
@@ -29,7 +29,7 @@ export const prepareQueryEnviroment = async () => {
     },
   };
   const state = await State.getState();
-  state.mobileConfig = { jwt: token };
+  state.mobileConfig = { jwt: token, localTableIds: [] };
 };
 
 export const sendViewToServer = async (view: any) => {


### PR DESCRIPTION
- the remote query test called the server without a jwt
- happened because the jwt is now in mobileconfig instead of localstorage