### PR TITLE
redirect, links and versioned tables on mobile

### DIFF
--- a/packages/saltcorn-data/models/field.ts
+++ b/packages/saltcorn-data/models/field.ts
@@ -13,7 +13,7 @@ const {
   freeVariables,
 } = require("./expression");
 import { sqlsanitize } from "@saltcorn/db-common/internal";
-const { InvalidAdminAction } = require("../utils");
+const { InvalidAdminAction, isNode } = require("../utils");
 import type { Where, SelectOptions, Row } from "@saltcorn/db-common/internal";
 import type {
   ErrorMessage,
@@ -972,7 +972,7 @@ class Field implements AbstractField {
         });
     await require("../db/state").getState().refresh_tables();
 
-    if (table.versioned && !(f.calculated && !f.stored)) {
+    if (isNode() && table.versioned && !(f.calculated && !f.stored)) {
       await db.query(
         `alter table ${schema}"${sqlsanitize(
           table.name

--- a/packages/saltcorn-data/tests/exact_views.test.ts
+++ b/packages/saltcorn-data/tests/exact_views.test.ts
@@ -253,7 +253,7 @@ describe("Show view", () => {
       ],
       response: !remoteQueries
         ? `<div class="row w-100"><div class="col-6"><div class="card mt-4 shadow"><div class="card-body"><a href="javascript:ajax_modal('/view/authorshow?id=1')">foo it</a></div></div></div><div class="col-6"><div class="text-start" style="min-height: 100px;border: 1px solid black;  background-color: #a9a7a7;  "><a href="https://countto.com/967">Herman Melville</a></div></div></div>`
-        : `<div class="row w-100"><div class="col-6"><div class="card mt-4 shadow"><div class="card-body"><a href="javascript:mobile_modal('/view/authorshow?id=1')">foo it</a></div></div></div><div class="col-6"><div class="text-start" style="min-height: 100px;border: 1px solid black;  background-color: #a9a7a7;  "><a href="https://countto.com/967">Herman Melville</a></div></div></div>`,
+        : `<div class="row w-100"><div class="col-6"><div class="card mt-4 shadow"><div class="card-body"><a href="javascript:mobile_modal('/view/authorshow?id=1')">foo it</a></div></div></div><div class="col-6"><div class="text-start" style="min-height: 100px;border: 1px solid black;  background-color: #a9a7a7;  "><a href="javascript:execLink('https://countto.com/967')">Herman Melville</a></div></div></div>`,
     });
     await test_show({
       layout: {

--- a/packages/saltcorn-markup/layout.ts
+++ b/packages/saltcorn-markup/layout.ts
@@ -293,7 +293,7 @@ const render = ({
               segment.link_textcol || "#000000"
             }`
           : null;
-
+      const mobile = typeof window !== "undefined";
       return wrap(
         segment,
         isTop,
@@ -301,10 +301,12 @@ const render = ({
         a(
           {
             href: segment.in_modal
-              ? typeof window === "undefined"
+              ? !mobile
                 ? `javascript:ajax_modal('${segment.url}');`
                 : `javascript:mobile_modal('${segment.url}');`
-              : segment.url,
+              : !mobile
+              ? segment.url
+              : `javascript:execLink('${segment.url}')`,
             class: [segment.link_style || "", segment.link_size || ""],
             target: segment.target_blank ? "_blank" : false,
             rel: segment.nofollow ? "nofollow" : false,

--- a/packages/saltcorn-mobile-app/www/index.html
+++ b/packages/saltcorn-mobile-app/www/index.html
@@ -146,10 +146,9 @@
       const initJwt = async () => {
         if (!(await saltcorn.data.db.tableExists("jwt_table"))) {
           await createJwtTable();
-        }
-        else {
+        } else {
           const jwt = await getJwt();
-          if(jwt) {
+          if (jwt) {
             const state = saltcorn.data.state.getState();
             state.mobileConfig.jwt = jwt;
           }
@@ -159,14 +158,13 @@
       const checkJWT = async () => {
         const state = saltcorn.data.state.getState();
         const jwt = state.mobileConfig.jwt;
-        if(jwt && jwt !== "undefined") {
+        if (jwt && jwt !== "undefined") {
           const response = await apiCall({
             method: "GET",
             path: "/auth/authenticated",
           });
           return response.data.authenticated;
-        }
-        else return false;
+        } else return false;
       };
 
       const initI18Next = async () => {

--- a/packages/saltcorn-mobile-app/www/js/routes/auth.js
+++ b/packages/saltcorn-mobile-app/www/js/routes/auth.js
@@ -90,6 +90,7 @@ const logoutAction = async () => {
   const response = await apiCall({ method: "GET", path: "/auth/logout" });
   if (response.data.success) {
     await removeJwt();
+    clearHistory();
     config.jwt = undefined;
     return {
       content: renderLoginView(config.entry_point, config.version_tag),

--- a/packages/saltcorn-mobile-app/www/js/routes/auth.js
+++ b/packages/saltcorn-mobile-app/www/js/routes/auth.js
@@ -1,4 +1,4 @@
-/*global sbAdmin2Layout, apiCall, removeJwt, saltcorn*/
+/*global sbAdmin2Layout, apiCall, removeJwt, saltcorn, clearHistory*/
 
 const prepareAuthForm = () => {
   return new saltcorn.data.models.Form({

--- a/packages/saltcorn-mobile-app/www/js/utils/global_utils.js
+++ b/packages/saltcorn-mobile-app/www/js/utils/global_utils.js
@@ -16,6 +16,10 @@ function addRoute(routeEntry) {
   routingHistory.push(routeEntry);
 }
 
+function clearHistory() {
+  routingHistory = [];
+}
+
 async function apiCall({ method, path, params, body, responseType }) {
   const config = saltcorn.data.state.getState().mobileConfig;
   const serverPath = config.server_path;
@@ -155,8 +159,12 @@ async function handleRoute(route, query, files) {
       files: files,
     });
     if (page.redirect) {
-      const { path, query } = splitPathQuery(page.redirect);
-      await handleRoute(path, query);
+      if (page.redirect.startsWith("http://localhost")) {
+        await gotoEntryView();
+      } else {
+        const { path, query } = splitPathQuery(page.redirect);
+        await handleRoute(path, query);
+      }
     } else if (page.content) {
       if (!page.replaceIframe) await replaceIframeInnerContent(page.content);
       else await replaceIframe(page.content);
@@ -173,7 +181,10 @@ async function handleRoute(route, query, files) {
 }
 
 async function goBack(steps = 1, exitOnFirstPage = false) {
-  if (exitOnFirstPage && routingHistory.length === 1) {
+  if (
+    routingHistory.length === 0 ||
+    (exitOnFirstPage && routingHistory.length === 1)
+  ) {
     navigator.app.exitApp();
   } else if (routingHistory.length <= steps) {
     routingHistory = [];

--- a/packages/server/public/saltcorn.js
+++ b/packages/server/public/saltcorn.js
@@ -599,11 +599,11 @@ function poll_mobile_build_finished(outDirName, pollCount, orginalBtnHtml) {
     data: { build_dir: outDirName },
     success: function (res) {
       if (!res.finished) {
-        if (pollCount >= 50) {
+        if (pollCount >= 100) {
           removeSpinner("buildMobileAppBtnId", orginalBtnHtml);
           notifyAlert({
             type: "danger",
-            text: "unable to get the build results",
+            text: "Unable to get the build results",
           });
         } else {
           setTimeout(() => {


### PR DESCRIPTION
- redirects starting with http://localhost are meant for the entrypoint
- links to pages
- don't fail for versioned tables (disable them for now on mobile)
- empty the routing history on logout the back button closes the app on the login view