### PR TITLE
no server data in the offline mode, improved user interaction

### DIFF
--- a/packages/saltcorn-data/models/config.ts
+++ b/packages/saltcorn-data/models/config.ts
@@ -74,8 +74,8 @@ const configTypes: ConfigTypes = {
     blurb:
       "The URL at which your site is available. For instance, https://example.com/",
   },
-  user_with_offline_data: {
-    type: "String",
+  last_offline_session: {
+    type: "Object",
     label: "User with offline data",
     default: "",
     blurb:

--- a/packages/saltcorn-markup/index.ts
+++ b/packages/saltcorn-markup/index.ts
@@ -8,7 +8,7 @@ import renderBuilder = require("./builder");
 import mkTable = require("./table");
 import tabs = require("./tabs");
 import tags = require("./tags");
-const { a, text, div, button, hr, time, i } = tags;
+const { a, text, div, button, hr, time, i, input } = tags;
 import layoutUtils = require("./layout_utils");
 const { alert } = layoutUtils;
 
@@ -250,6 +250,7 @@ export = {
   a,
   i,
   button,
+  input,
   hr,
   alert,
 };

--- a/packages/saltcorn-mobile-app/www/index.html
+++ b/packages/saltcorn-mobile-app/www/index.html
@@ -176,19 +176,6 @@
         });
       };
 
-      const tryDownloadServerData = async (alerts) => {
-        try {
-          await offlineHelper.downloadServerData();
-        } catch (error) {
-          alerts.push({
-            type: "warning",
-            msg: `Unable to download the server data: ${
-              error.message ? error.message : "unknown error"
-            }`,
-          });
-        }
-      };
-
       // the app comes back from background
       const onResume = async () => {
         const state = saltcorn.data.state.getState();
@@ -197,10 +184,28 @@
           mobileConfig.networkState = navigator.connection.type;
           if (
             mobileConfig.networkState === "none" &&
-            !mobileConfig.isOfflineMode
+            !mobileConfig.isOfflineMode &&
+            mobileConfig.jwt
           ) {
-            // starts the offline mode, if needed
-            await gotoEntryView();
+            await offlineHelper.startOfflineMode();
+            clearHistory();
+            if (mobileConfig.user_id) await gotoEntryView();
+            else {
+              const decodedJwt = jwt_decode(mobileConfig.jwt);
+              mobileConfig.role_id = decodedJwt.user.role_id
+                ? decodedJwt.user.role_id
+                : 100;
+              mobileConfig.user_id = decodedJwt.user.id;
+              mobileConfig.user_name = decodedJwt.user.email;
+              mobileConfig.language = decodedJwt.user.language;
+              mobileConfig.isPublicUser = false;
+            }
+            addRoute({ route: entryPoint, query: undefined });
+            const page = await router.resolve({
+              pathname: mobileConfig.entry_point,
+              fullWrap: true,
+              alerts: [],
+            });
           }
         }
       };
@@ -272,32 +277,38 @@
             mobileConfig.isPublicUser = false;
             await i18next.changeLanguage(mobileConfig.language);
             if (mobileConfig.allowOfflineMode) {
-              const userWithOfflineData = await offlineHelper.lastOfflineUser();
+              const { offlineUser, upload_started_at, upload_ended_at } =
+                (await offlineHelper.getLastOfflineSession()) || {};
               if (networkDisabled) {
-                if (
-                  userWithOfflineData &&
-                  userWithOfflineData !== mobileConfig.user_name
-                )
+                if (offlineUser && offlineUser !== mobileConfig.user_name)
                   throw new Error(
-                    `The offline mode is not available, '${userWithOfflineData}' has not yet uploaded offline data.`
+                    `The offline mode is not available, '${offlineUser}' has not yet uploaded offline data.`
                   );
                 else {
                   await offlineHelper.startOfflineMode();
-                  alerts.push({ type: "info", msg: "You are in offline mode" });
+                  alerts.push({
+                    type: "info",
+                    msg: offlineHelper.getOfflineMsg(),
+                  });
                 }
-              } else {
-                if (userWithOfflineData) {
-                  if (userWithOfflineData === mobileConfig.user_name)
-                    alerts.push({
-                      type: "info",
-                      msg: "You have offline data, open the Sync menu to handle it.",
-                    });
-                  else
+              } else if (offlineUser) {
+                if (offlineUser === mobileConfig.user_name) {
+                  if (upload_started_at && !upload_ended_at) {
                     alerts.push({
                       type: "warning",
-                      msg: `'${userWithOfflineData}' has not yet uploaded offline data.`,
+                      msg: "Please check if your offline data is already online. An upload was started but did not finish.",
                     });
-                } else await tryDownloadServerData(alerts);
+                  } else {
+                    alerts.push({
+                      type: "info",
+                      msg: "You have offline data, to handle it open the Network menu.",
+                    });
+                  }
+                } else
+                  alerts.push({
+                    type: "warning",
+                    msg: `'${offlineUser}' has not yet uploaded offline data.`,
+                  });
               }
             }
             addRoute({ route: entryPoint, query: undefined });
@@ -315,8 +326,10 @@
             await replaceIframe(page.content);
           }
         } catch (error) {
+          state.mobileConfig.inErrorState = true;
           const page = await router.resolve({
             pathname: "get/error_page",
+            fullWrap: true,
             alerts: [
               {
                 type: "error",

--- a/packages/saltcorn-mobile-app/www/js/routes/common.js
+++ b/packages/saltcorn-mobile-app/www/js/routes/common.js
@@ -25,7 +25,7 @@ const parseQuery = (queryStr) => {
 
 const layout = () => {
   const state = saltcorn.data.state.getState();
-  return state.getLayout({ role_id: state.mobileConfig.role_id });
+  return state.getLayout({ role_id: state.mobileConfig.role_id || 100 });
 };
 
 const sbAdmin2Layout = () => {
@@ -40,58 +40,81 @@ const getMenu = (req) => {
     role,
     req.__
   );
-  const allowSignup = state.getConfig("allow_signup");
-  const userName = mobileCfg.user_name;
-  const authItems = mobileCfg.isPublicUser
-    ? [
-        { link: "javascript:execLink('/auth/login')", label: req.__("Login") },
-        ...(allowSignup
-          ? [
+  if (mobileCfg.inErrorState) {
+    const entryLink = mobileCfg.entry_point?.startsWith("get")
+      ? mobileCfg.entry_point.substr(3)
+      : null;
+    return entryLink
+      ? [
+          {
+            section: "Reload",
+            items: [
               {
-                link: "javascript:execLink('/auth/signup')",
-                label: req.__("Sign up"),
+                link: `javascript:parent.gotoEntryView()`,
+                icon: "fas fa-sync",
+                label: "Reload",
               },
-            ]
-          : []),
-      ]
-    : [
-        {
-          label: req.__("User"),
-          icon: "far fa-user",
-          isUser: true,
-          subitems: [
-            { label: userName },
-            {
-              link: `javascript:logout();`,
-              icon: "fas fa-sign-out-alt",
-              label: "Logout",
-            },
-          ],
-        },
-      ];
-  const result = [];
-  if (extraMenu.length > 0)
+            ],
+          },
+        ]
+      : [];
+  } else {
+    const allowSignup = state.getConfig("allow_signup");
+    const userName = mobileCfg.user_name;
+    const authItems = mobileCfg.isPublicUser
+      ? [
+          {
+            link: "javascript:execLink('/auth/login')",
+            label: req.__("Login"),
+          },
+          ...(allowSignup
+            ? [
+                {
+                  link: "javascript:execLink('/auth/signup')",
+                  label: req.__("Sign up"),
+                },
+              ]
+            : []),
+        ]
+      : [
+          {
+            label: req.__("User"),
+            icon: "far fa-user",
+            isUser: true,
+            subitems: [
+              { label: userName },
+              {
+                link: `javascript:logout();`,
+                icon: "fas fa-sign-out-alt",
+                label: "Logout",
+              },
+            ],
+          },
+        ];
+    const result = [];
+    if (extraMenu.length > 0)
+      result.push({
+        section: req.__("Menu"),
+        items: extraMenu,
+      });
     result.push({
-      section: req.__("Menu"),
-      items: extraMenu,
+      section: req.__("User"),
+      isUser: true,
+      items: authItems,
     });
-  result.push({
-    section: req.__("User"),
-    isUser: true,
-    items: authItems,
-  });
-  if (mobileCfg.allowOfflineMode)
-    result.push({
-      section: "Sync",
-      items: [
-        {
-          link: "javascript:execLink('/sync/sync_settings')",
-          icon: "fas fa-sync",
-          label: "Sync",
-        },
-      ],
-    });
-  return result;
+    if (mobileCfg.allowOfflineMode)
+      result.push({
+        section: "Network",
+        items: [
+          {
+            link: "javascript:execLink('/sync/sync_settings')",
+            icon: "fas fa-sync",
+            label: "Network",
+          },
+        ],
+      });
+    return result;
+  }
 };
 
 const prepareAlerts = (context, req) => {

--- a/packages/saltcorn-mobile-app/www/js/routes/delete.js
+++ b/packages/saltcorn-mobile-app/www/js/routes/delete.js
@@ -1,15 +1,17 @@
-/*global i18next, apiCall, saltcorn*/
+/*global i18next, apiCall, saltcorn, offlineHelper*/
 
 // post/delete/:name/:id
 const deleteRows = async (context) => {
   const { name, id } = context.params;
   const table = await saltcorn.data.models.Table.findOne({ name });
-  const mobileConfig = saltcorn.data.state.getState().mobileConfig;
-  if (mobileConfig.isOfflineMode)
-    throw new Error(i18next.t("Deletes are not supported in offline mode."));
-  if (mobileConfig.localTableIds.indexOf(table.id) >= 0) {
-    if (mobileConfig.role_id <= table.min_role_write) {
+  const { isOfflineMode, localTableIds, role_id } =
+    saltcorn.data.state.getState().mobileConfig;
+  if (isOfflineMode || localTableIds.indexOf(table.id) >= 0) {
+    if (role_id <= table.min_role_write) {
       await table.deleteRows({ id });
+    }
+    if (isOfflineMode && !(await offlineHelper.hasOfflineRows())) {
+      await offlineHelper.setOfflineSession(null);
     }
     // TODO 'table.is_owner' check?
     else {

--- a/packages/saltcorn-mobile-app/www/js/routes/edit.js
+++ b/packages/saltcorn-mobile-app/www/js/routes/edit.js
@@ -1,4 +1,4 @@
-/*global i18next, apiCall, saltcorn*/
+/*global i18next, apiCall, saltcorn, offlineHelper*/
 
 // /toggle/:name/:id/:field_name
 const postToggleField = async (context) => {
@@ -11,8 +11,8 @@ const postToggleField = async (context) => {
     if (role_id > table.min_role_write)
       throw new Error(i18next.t("Not authorized"));
     await table.toggleBool(+id, field_name);
-    if (isOfflineMode)
-      await state.setConfig("user_with_offline_data", user_name);
+    if (isOfflineMode && !(await offlineHelper.getLastOfflineSession()))
+      await offlineHelper.setOfflineSession({ offlineUser: user_name });
   } else {
     await apiCall({
       method: "POST",

--- a/packages/saltcorn-mobile-app/www/js/routes/error.js
+++ b/packages/saltcorn-mobile-app/www/js/routes/error.js
@@ -1,18 +1,5 @@
-/*global layout, getHeaders, saltcorn*/
+/*global wrapContents, MobileRequest */
 
 const getErrorView = async (context) => {
-  const state = saltcorn.data.state.getState();
-  const wrappedContent = layout().wrap({
-    title: "Error",
-    body: { above: [""] },
-    alerts: context.alerts ,
-    role: state.mobileConfig.role_id,
-    headers: getHeaders(),
-    menu: [],
-    bodyClass: "",
-    currentUrl: "",
-    brand: {},
-  });
-
-  return { content: wrappedContent, title: "Error" };
+  return wrapContents("", "Error", context, new MobileRequest());
 };

--- a/packages/saltcorn-mobile-app/www/js/routes/init.js
+++ b/packages/saltcorn-mobile-app/www/js/routes/init.js
@@ -1,4 +1,4 @@
-/*global postView, postViewRoute, getView, postToggleField, deleteRows, postPageAction, getPage, getLoginView, logoutAction, getSignupView, getErrorView, window, getSyncView, getSyncModalContent, getAskOverwriteDialog, getSyncSettingsView*/
+/*global postView, postViewRoute, getView, postToggleField, deleteRows, postPageAction, getPage, getLoginView, logoutAction, getSignupView, getErrorView, window, getSyncSettingsView, getAskDeleteOfflineData, getAskUploadNotEnded */
 // TODO module namespacese
 
 const initRoutes = async () => {
@@ -52,8 +52,12 @@ const initRoutes = async () => {
       action: getSyncSettingsView,
     },
     {
-      path: "get/sync/ask_overwrite",
-      action: getAskOverwriteDialog,
+      path: "get/sync/ask_upload_not_ended",
+      action: getAskUploadNotEnded,
+    },
+    {
+      path: "get/sync/ask_delete_offline_data",
+      action: getAskDeleteOfflineData,
     },
   ];
   window.router = new window.UniversalRouter(routes);

--- a/packages/saltcorn-mobile-app/www/js/routes/sync.js
+++ b/packages/saltcorn-mobile-app/www/js/routes/sync.js
@@ -1,6 +1,9 @@
 /*global saltcorn, wrapContents, MobileRequest, */
 
+// get/sync/sync_settings
 const getSyncSettingsView = (context) => {
+  const state = saltcorn.data.state.getState();
+  const { isOfflineMode } = state.mobileConfig;
   const content = saltcorn.markup.div(
     { class: "container" },
     saltcorn.markup.div(
@@ -9,11 +12,51 @@ const getSyncSettingsView = (context) => {
         { class: "col-9" },
         saltcorn.markup.div(
           { class: "fs-6 fw-bold text-decoration-underline" },
-          "Upload offline data"
+          "Mode"
         ),
         saltcorn.markup.div(
-          "Upload the data from your last offline session to the server."
+          {
+            id: "onlineDescId",
+            class: isOfflineMode ? "d-none" : "d-block",
+          },
+          "You are online. The data comes from the server."
+        ),
+        saltcorn.markup.div(
+          {
+            id: "offlineDescId",
+            class: isOfflineMode ? "d-block" : "d-none",
+          },
+          "You are offline. The data comes from your device."
         )
+      ),
+      saltcorn.markup.div(
+        { class: "col-3" },
+        saltcorn.markup.div(
+          {
+            class: "form-check form-switch",
+            style: "transform: scale(1.38); margin-left: 10px;",
+          },
+          saltcorn.markup.input({
+            class: "form-check-input",
+            type: "checkbox",
+            role: "switch",
+            id: "networkModeSwitcherId",
+            checked: !isOfflineMode,
+            onClick: "switchNetworkMode()",
+          })
+        )
+      )
+    ),
+    saltcorn.markup.hr(),
+    saltcorn.markup.div(
+      { class: "row" },
+      saltcorn.markup.div(
+        { class: "col-9" },
+        saltcorn.markup.div(
+          { class: "fs-6 fw-bold text-decoration-underline" },
+          "Upload offline data"
+        ),
+        saltcorn.markup.div("Upload the data from your last offline session.")
       ),
       saltcorn.markup.div(
         { class: "col-3" },
@@ -21,7 +64,7 @@ const getSyncSettingsView = (context) => {
           {
             class: "btn btn-primary",
             type: "button",
-            onClick: "callUploadSync()",
+            onClick: "callUpload()",
           },
           saltcorn.markup.i({ class: "fas fa-sync" })
         )
@@ -34,11 +77,9 @@ const getSyncSettingsView = (context) => {
         { class: "col-9" },
         saltcorn.markup.div(
           { class: "fs-6 fw-bold text-decoration-underline" },
-          "Download server data"
+          "Delete offline data"
         ),
-        saltcorn.markup.div(
-          "Download the latest data for your next offline session."
-        )
+        saltcorn.markup.div("Delete all offline data.")
       ),
       saltcorn.markup.div(
         { class: "col-3" },
@@ -46,9 +87,9 @@ const getSyncSettingsView = (context) => {
           {
             class: "btn btn-primary",
             type: "button",
-            onClick: "callDownloadSync()",
+            onClick: "deleteOfflineDataClicked()",
           },
-          saltcorn.markup.i({ class: "fas fa-sync" })
+          saltcorn.markup.i({ class: "fas fa-trash" })
         )
       )
     ),
@@ -57,12 +98,13 @@ const getSyncSettingsView = (context) => {
   return wrapContents(content, "Sync Settings", context, new MobileRequest());
 };
 
-// get/sync/ask_overwrite
-const getAskOverwriteDialog = (context) => {
+// get/sync/ask_upload_not_ended
+const getAskUploadNotEnded = (context) => {
   const content = saltcorn.markup.div(
     saltcorn.markup.div(
       { class: "mb-3 h6" },
-      "This replaces your offline data."
+      "A previous upload did not finish." +
+        "Please check if your data is already online."
     ),
     saltcorn.markup.button(
       {
@@ -76,9 +118,36 @@ const getAskOverwriteDialog = (context) => {
       {
         class: "btn btn-primary close",
         type: "button",
-        onClick: "closeModal(); callDownloadSync(true)",
+        onClick: "closeModal(); callUpload(true)",
       },
-      "Download anyway"
+      "Upload anyway"
+    )
+  );
+  return wrapContents(content, "Warning", context, new MobileRequest());
+};
+
+// get/sync/ask_delete_offline_data
+const getAskDeleteOfflineData = (context) => {
+  const content = saltcorn.markup.div(
+    saltcorn.markup.div(
+      { class: "mb-3 h6" },
+      "Do you really want to delete all offline data from your device?"
+    ),
+    saltcorn.markup.button(
+      {
+        class: "btn btn-secondary me-2",
+        type: "button",
+        "data-bs-dismiss": "modal",
+      },
+      "Close"
+    ),
+    saltcorn.markup.button(
+      {
+        class: "btn btn-primary close",
+        type: "button",
+        onClick: "closeModal(); deleteOfflineData()",
+      },
+      "Delete"
     )
   );
   return wrapContents(content, "Warning", context, new MobileRequest());

--- a/packages/saltcorn-mobile-app/www/js/routes/view.js
+++ b/packages/saltcorn-mobile-app/www/js/routes/view.js
@@ -1,4 +1,4 @@
-/*global MobileRequest, MobileResponse, parseQuery, wrapContents, saltcorn*/
+/*global MobileRequest, MobileResponse, parseQuery, wrapContents, saltcorn, offlineHelper*/
 
 /**
  *
@@ -35,8 +35,8 @@ const postView = async (context) => {
     },
     view.isRemoteTable()
   );
-  if (mobileCfg.isOfflineMode)
-    await state.setConfig("user_with_offline_data", mobileCfg.user_name);
+  if (mobileCfg.isOfflineMode && !(await offlineHelper.getLastOfflineSession()))
+    await offlineHelper.setOfflineSession({ offlineUser: mobileCfg.user_name });
   return res.getJson();
 };
 
@@ -60,7 +60,8 @@ const postViewRoute = async (context) => {
     { req, res },
     view.isRemoteTable()
   );
-  if (isOfflineMode) await state.setConfig("user_with_offline_data", user_name);
+  if (isOfflineMode && !(await offlineHelper.getLastOfflineSession()))
+    await offlineHelper.setOfflineSession({ offlineUser: user_name });
   return res.getJson();
 };
 

--- a/packages/saltcorn-mobile-app/www/js/utils/iframe_view_utils.js
+++ b/packages/saltcorn-mobile-app/www/js/utils/iframe_view_utils.js
@@ -110,20 +110,25 @@ async function login(e, entryPoint, isSignup) {
     await parent.i18next.changeLanguage(config.language);
     const alerts = [];
     if (config.allowOfflineMode) {
-      const userWithOfflineData = await parent.offlineHelper.lastOfflineUser();
-      if (!userWithOfflineData) await parent.offlineHelper.downloadServerData();
-      else {
-        if (userWithOfflineData === config.user_name) {
+      const { offlineUser, upload_started_at, upload_ended_at } =
+        (await parent.offlineHelper.getLastOfflineSession()) || {};
+      if (offlineUser === config.user_name) {
+        if (upload_started_at && !upload_ended_at) {
           alerts.push({
-            type: "info",
-            msg: "You have offline data, open the Sync menu to handle it.",
+            type: "warning",
+            msg: "Please check if your offline data is already online. An upload was started but did not finish.",
           });
         } else {
           alerts.push({
-            type: "warning",
-            msg: `'${userWithOfflineData}' has not yet uploaded offline data.`,
+            type: "info",
+            msg: "You have offline data, to handle it open the Network menu.",
           });
         }
+      } else if (offlineUser) {
+        alerts.push({
+          type: "warning",
+          msg: `'${offlineUser}' has not yet uploaded offline data.`,
+        });
       }
     }
     alerts.push({
@@ -361,21 +366,30 @@ async function mobile_modal(url, opts = {}) {
       mobileConfig.networkState === "none" &&
       mobileConfig.allowOfflineMode &&
       !mobileConfig.isOfflineMode
-    )
+    ) {
       await parent.offlineHelper.startOfflineMode();
-    const page = await parent.router.resolve({
-      pathname: `get${path}`,
-      query: query,
-      alerts: mobileConfig.isOfflineMode
-        ? [{ type: "info", msg: "You are in offline mode" }]
-        : [],
-    });
-    const modalContent = page.content;
-    const title = page.title;
-    if (title) $("#scmodal .modal-title").html(title);
-    $("#scmodal .modal-body").html(modalContent);
-    new bootstrap.Modal($("#scmodal")).show();
-    // onOpen onClose initialize_page?
+      parent.clearHistory();
+      await parent.gotoEntryView();
+    } else {
+      const page = await parent.router.resolve({
+        pathname: `get${path}`,
+        query: query,
+        alerts: mobileConfig.isOfflineMode
+          ? [
+              {
+                type: "info",
+                msg: parent.offlineHelper.getOfflineMsg(),
+              },
+            ]
+          : [],
+      });
+      const modalContent = page.content;
+      const title = page.title;
+      if (title) $("#scmodal .modal-title").html(title);
+      $("#scmodal .modal-body").html(modalContent);
+      new bootstrap.Modal($("#scmodal")).show();
+      // onOpen onClose initialize_page?
+    }
   } catch (error) {
     parent.showAlerts([
       {
@@ -524,63 +538,166 @@ async function view_post(viewname, route, data, onDone) {
   }
 }
 
-async function callUploadSync() {
-  if (!(await parent.offlineHelper.lastOfflineUser())) {
+function setNetworSwitcherOn() {
+  $("#networkModeSwitcherId").prop("checked", true);
+  $("#onlineDescId").prop("class", "d-block");
+  $("#offlineDescId").prop("class", "d-none");
+}
+
+function setNetworkSwitcherOff() {
+  $("#networkModeSwitcherId").prop("checked", false);
+  $("#onlineDescId").prop("class", "d-none");
+  $("#offlineDescId").prop("class", "d-block");
+}
+
+async function switchNetworkMode() {
+  try {
+    const state = parent.saltcorn.data.state.getState();
+    const { isOfflineMode, networkState } = state.mobileConfig;
+    if (!isOfflineMode) {
+      await parent.offlineHelper.startOfflineMode();
+      parent.clearHistory();
+      parent.addRoute({ route: "/" });
+      parent.addRoute({ route: "get/sync/sync_settings" });
+      parent.showAlerts([
+        {
+          type: "info",
+          msg: parent.offlineHelper.getOfflineMsg(),
+        },
+      ]);
+    } else {
+      if (networkState === "none")
+        throw new Error("No internet connection is available.");
+      await parent.offlineHelper.endOfflineMode();
+      parent.clearHistory();
+      parent.addRoute({ route: "/" });
+      parent.addRoute({ route: "get/sync/sync_settings" });
+      parent.showAlerts([
+        {
+          type: "info",
+          msg: "You are online again.",
+        },
+      ]);
+    }
+  } catch (error) {
+    parent.showAlerts([
+      {
+        type: "error",
+        msg: `Unable to change the network mode: ${
+          error.message ? error.message : "Unknown error"
+        }`,
+      },
+    ]);
+  } finally {
+    const { isOfflineMode } =
+      parent.saltcorn.data.state.getState().mobileConfig;
+    if (isOfflineMode) setNetworkSwitcherOff();
+    else setNetworSwitcherOn();
+  }
+}
+
+async function callUpload(force = false) {
+  const lastOfflineSession = await parent.offlineHelper.getLastOfflineSession();
+  const mobileConfig = parent.saltcorn.data.state.getState().mobileConfig;
+  if (!lastOfflineSession?.offlineUser) {
     parent.showAlerts([
       {
         type: "error",
         msg: "You don't have any offline data.",
       },
     ]);
+  } else if (mobileConfig.networkState === "none") {
+    parent.showAlerts([
+      {
+        type: "error",
+        msg: "You don't have an internet connection.",
+      },
+    ]);
   } else {
-    showLoadSpinner();
-    try {
-      await parent.offlineHelper.uploadLocalData();
-      await parent.offlineHelper.endOfflineMode();
-      parent.clearAlerts();
-      parent.showAlerts([
-        {
-          type: "info",
-          msg: "Sucessfully uploaded your local data.",
-        },
-      ]);
-    } catch (error) {
-      parent.errorAlert(error);
-    } finally {
-      removeLoadSpinner();
+    if (
+      !force &&
+      lastOfflineSession.upload_started_at &&
+      !lastOfflineSession.upload_ended_at
+    ) {
+      await mobile_modal("/sync/ask_upload_not_ended");
+    } else {
+      const wasOffline = mobileConfig.isOfflineMode;
+      try {
+        showLoadSpinner();
+        mobileConfig.inLoadState = true;
+        await parent.offlineHelper.uploadLocalData();
+        await parent.offlineHelper.clearLocalData();
+        await parent.offlineHelper.endOfflineMode();
+        parent.clearHistory();
+        parent.addRoute({ route: "/" });
+        parent.addRoute({ route: "get/sync/sync_settings" });
+        parent.clearAlerts();
+        if (!wasOffline) {
+          parent.showAlerts([
+            {
+              type: "info",
+              msg: "Uploaded your offline data.",
+            },
+          ]);
+        } else if (wasOffline) {
+          setNetworSwitcherOn();
+          parent.showAlerts([
+            {
+              type: "info",
+              msg: "Uploaded your offline data, you are online again.",
+            },
+          ]);
+        }
+      } catch (error) {
+        parent.errorAlert(error);
+      } finally {
+        mobileConfig.inLoadState = false;
+        removeLoadSpinner();
+      }
     }
   }
 }
 
-async function callDownloadSync(force = false) {
-  const lastOfflineUser = await parent.offlineHelper.lastOfflineUser();
+async function deleteOfflineDataClicked() {
+  const lastOfflineSession = await parent.offlineHelper.getLastOfflineSession();
   const { user_name } = parent.saltcorn.data.state.getState().mobileConfig;
-  if (lastOfflineUser === user_name && !force) {
-    await mobile_modal("/sync/ask_overwrite");
-  } else if (lastOfflineUser && !force) {
+  if (!lastOfflineSession?.offlineUser) {
     parent.showAlerts([
       {
         type: "error",
-        msg: `The user '${lastOfflineUser}' has offline data, the download is not available.`,
+        msg: "You don't have any offline data.",
+      },
+    ]);
+  } else if (lastOfflineSession.offlineUser !== user_name) {
+    parent.showAlerts([
+      {
+        type: "error",
+        msg: `The offline data is owned by '${lastOfflineSession.offlineUser}'.`,
       },
     ]);
   } else {
+    mobile_modal("/sync/ask_delete_offline_data");
+  }
+}
+
+async function deleteOfflineData() {
+  const mobileConfig = parent.saltcorn.data.state.getState().mobileConfig;
+  try {
+    mobileConfig.inLoadState = true;
     showLoadSpinner();
-    try {
-      await parent.offlineHelper.downloadServerData();
-      await parent.offlineHelper.endOfflineMode();
-      parent.clearAlerts();
-      parent.showAlerts([
-        {
-          type: "info",
-          msg: "Sucessfully updated your local data.",
-        },
-      ]);
-    } catch (error) {
-      parent.errorAlert(error);
-    } finally {
-      removeLoadSpinner();
-    }
+    await parent.offlineHelper.clearLocalData();
+    await parent.offlineHelper.setOfflineSession(null);
+    parent.showAlerts([
+      {
+        type: "info",
+        msg: "Deleted your offline data.",
+      },
+    ]);
+  } catch (error) {
+    parent.errorAlert(error);
+  } finally {
+    mobileConfig.inLoadState = false;
+    removeLoadSpinner();
   }
 }
 

--- a/packages/saltcorn-mobile-app/www/js/utils/offline_mode_helper.js
+++ b/packages/saltcorn-mobile-app/www/js/utils/offline_mode_helper.js
@@ -1,48 +1,13 @@
-/*global $, apiCall, saltcorn, apiCall, navigator, clearAlerts*/
+/*global $, apiCall, saltcorn, navigator, clearAlerts*/
 
 var offlineHelper = (() => {
-  const loadServerData = async () => {
-    const response = await apiCall({
-      method: "GET",
-      path: "/sync/table_data",
-    });
-    return response.data;
-  };
-  const updateLocalData = async (data) => {
-    try {
-      await saltcorn.data.db.query("PRAGMA foreign_keys = OFF;");
-      await saltcorn.data.db.query("BEGIN TRANSACTION");
-      // replace all data
-      for (const [k, v] of Object.entries(data)) {
-        await saltcorn.data.db.query(
-          `delete from "${saltcorn.data.db.sqlsanitize(k)}"`
-        );
-        for (const row of v.rows) {
-          await saltcorn.data.db.insert(k, row);
-        }
-      }
-      await saltcorn.data.db.query("COMMIT TRANSACTION");
-    } catch (error) {
-      await saltcorn.data.db.query("ROLLBACK TRANSACTION");
-      throw error;
-    } finally {
-      await saltcorn.data.db.query("PRAGMA foreign_keys = ON;");
-    }
-  };
-
-  const loadLocalData = async () => {
+  const loadOfflineData = async (localTableIds) => {
     const result = {};
-    const { user_id } = saltcorn.data.state.getState().mobileConfig;
-    const user = await saltcorn.data.models.User.findOne({ id: user_id });
-    if (!user) throw new Error(`The user with id '${user_id}' does not exist.`);
     for (const table of await saltcorn.data.models.Table.find()) {
-      // ignore min_role_read, one can insert a row which is not readable
-      // but that invisible row should be synched
-      const rows =
-        user.role_id > table.min_role_write
-          ? (await table.getRows()).filter((row) => table.is_owner(user, row))
-          : await table.getRows();
-      result[table.name] = rows;
+      if (table.name !== "users" && !localTableIds.indexOf(table.id) >= 0) {
+        const rows = await table.getRows();
+        if (rows.length > 0) result[table.name] = rows;
+      }
     }
     return result;
   };
@@ -56,30 +21,28 @@ var offlineHelper = (() => {
     });
     return response.data;
   };
-  const applyTranslatedIds = async (translateIds) => {
-    try {
-      await saltcorn.data.db.query("PRAGMA foreign_keys = OFF;");
-      await saltcorn.data.db.query("BEGIN TRANSACTION");
-      for (const [k, v] of Object.entries(translateIds)) {
-        const table = saltcorn.data.models.Table.findOne({ name: k });
-        for (const { from, to } of v) {
-          await table.updateRow({ id: to }, from);
-        }
-      }
-      await saltcorn.data.db.query("COMMIT TRANSACTION");
-    } catch (error) {
-      await saltcorn.data.db.query("ROLLBACK TRANSACTION");
-      throw error;
-    } finally {
-      await saltcorn.data.db.query("PRAGMA foreign_keys = ON;");
-    }
+  const setUploadStartedTime = async (date) => {
+    const state = saltcorn.data.state.getState();
+    const oldSession = await state.getConfig("last_offline_session");
+    const newSession = { ...oldSession };
+    newSession.upload_started_at = date;
+    newSession.upload_ended_at = null;
+    await state.setConfig("last_offline_session", newSession);
+  };
+  const setUploadFinishedTime = async (date) => {
+    const state = saltcorn.data.state.getState();
+    const oldSession = await state.getConfig("last_offline_session");
+    const newSession = { ...oldSession };
+    newSession.upload_ended_at = date;
+    await state.setConfig("last_offline_session", newSession);
   };
 
   return {
     startOfflineMode: async () => {
       const state = saltcorn.data.state.getState();
       const mobileConfig = state.mobileConfig;
-      const oldOfflineUser = await offlineHelper.lastOfflineUser();
+      const oldOfflineUser = (await offlineHelper.getLastOfflineSession())
+        ?.offlineUser;
       if (oldOfflineUser && oldOfflineUser !== mobileConfig.user_name) {
         throw new Error(
           `The offline mode is not available, '${oldOfflineUser}' has not yet uploaded offline data.`
@@ -92,28 +55,45 @@ var offlineHelper = (() => {
       const state = saltcorn.data.state.getState();
       const mobileConfig = state.mobileConfig;
       mobileConfig.isOfflineMode = false;
-      await state.setConfig("user_with_offline_data", "");
+      if (!(await offlineHelper.hasOfflineRows()))
+        await state.setConfig("last_offline_session", null);
     },
-    lastOfflineUser: async () => {
+    getLastOfflineSession: async () => {
       const state = saltcorn.data.state.getState();
-      return await state.getConfig("user_with_offline_data");
+      return await state.getConfig("last_offline_session");
+    },
+    setOfflineSession: async (sessObj) => {
+      const state = saltcorn.data.state.getState();
+      await state.setConfig("last_offline_session", sessObj);
     },
     uploadLocalData: async () => {
-      const lastOfflineUser = await offlineHelper.lastOfflineUser();
+      const lastOfflineUser = (await offlineHelper.getLastOfflineSession())
+        ?.offlineUser;
       if (!lastOfflineUser) throw new Error("You don't have any offline data.");
-      const { user_name } = saltcorn.data.state.getState().mobileConfig;
+      const { user_name, localTableIds } =
+        saltcorn.data.state.getState().mobileConfig;
       if (lastOfflineUser !== user_name)
         throw new Error(
           `The upload is not available, '${lastOfflineUser}' has not yet uploaded offline data.`
         );
-      const fromSqlite = await loadLocalData();
-      const { translateIds } = await sendToServer(fromSqlite);
-      if (translateIds && Object.keys(translateIds).length > 0)
-        await applyTranslatedIds(translateIds);
+      const fromSqlite = await loadOfflineData(localTableIds);
+      try {
+        await setUploadStartedTime(new Date());
+        await sendToServer(fromSqlite);
+        await setUploadFinishedTime(new Date());
+      } catch (error) {
+        await setUploadFinishedTime(null);
+        throw error;
+      }
     },
-    downloadServerData: async () => {
-      const fromServer = await loadServerData();
-      await updateLocalData(fromServer);
+    clearLocalData: async () => {
+      const { localTableIds } = saltcorn.data.state.getState().mobileConfig;
+      const tables = await saltcorn.data.models.Table.find();
+      for (const table of tables) {
+        if (table.name !== "users" && !localTableIds.indexOf(table.id) >= 0) {
+          await table.deleteRows();
+        }
+      }
     },
     offlineCallback: async () => {
       const mobileConfig = saltcorn.data.state.getState().mobileConfig;
@@ -124,23 +104,33 @@ var offlineHelper = (() => {
       if (mobileConfig.isOfflineMode) {
         const iframeWindow = $("#content-iframe")[0].contentWindow;
         if (iframeWindow) {
-          if (await offlineHelper.lastOfflineUser()) {
-            iframeWindow.notifyAlert(
-              `An internet connection is available, to handle your offline data Click ${saltcorn.markup.a(
-                {
-                  href: "javascript:execLink('/sync/sync_settings')",
-                },
-                "here"
-              )}`
-            );
-          } else {
-            clearAlerts();
-            iframeWindow.notifyAlert("You are online again.");
-            mobileConfig.isOfflineMode = false;
-          }
+          clearAlerts();
+          iframeWindow.notifyAlert(
+            `An internet connection is available, to end the offline mode click ${saltcorn.markup.a(
+              {
+                href: "javascript:execLink('/sync/sync_settings')",
+              },
+              "here"
+            )}`
+          );
         }
       }
       mobileConfig.networkState = navigator.connection.type;
+    },
+    hasOfflineRows: async () => {
+      const { localTableIds } = saltcorn.data.state.getState().mobileConfig;
+      for (const table of await saltcorn.data.models.Table.find()) {
+        if (table.name !== "users" && !localTableIds.indexOf(table.id) >= 0) {
+          if ((await table.countRows()) > 0) return true;
+        }
+      }
+      return false;
+    },
+    getOfflineMsg: () => {
+      const { networkState } = saltcorn.data.state.getState().mobileConfig;
+      return networkState === "none"
+        ? "You are offline."
+        : "You are offline, an internet connection is available.";
     },
   };
 })();

--- a/packages/saltcorn-types/base_types.ts
+++ b/packages/saltcorn-types/base_types.ts
@@ -351,6 +351,8 @@ export type MobileConfig = {
   language?: string;
   isPublicUser?: boolean;
   jwt?: string;
+  inErrorState?: boolean;
+  inLoadState?: boolean;
 };
 
 export type JoinFieldOption = {

--- a/packages/server/routes/sync.js
+++ b/packages/server/routes/sync.js
@@ -1,53 +1,16 @@
 const { error_catcher } = require("./utils.js");
-const Table = require("@saltcorn/data/models/table");
 const Router = require("express-promise-router");
 const db = require("@saltcorn/data/db");
 const { getState } = require("@saltcorn/data/db/state");
+const Table = require("@saltcorn/data/models/table");
 
 const router = new Router();
 module.exports = router;
 
-/**
- * Send all rows from a user, so that they can be used in an offline session with the mobile app
- */
-router.get(
-  "/table_data",
-  error_catcher(async (req, res) => {
-    // TODO optimsie: hash over all rows or dynamic user specific
-    // TODO public user
-    // TODO split large data 10 000 rows?
-    getState().log(
-      4,
-      `GET /sync/table_data user: '${req.user ? req.user.id : "public"}'`
-    );
-    const allTables = await Table.find();
-    const result = {};
-    const selectOpts = req.user ? { forUser: req.user } : { forPublic: true };
-    for (const table of allTables) {
-      const rows = await table.getRows({}, selectOpts);
-      if (
-        req.user &&
-        table.name === "users" &&
-        !rows.find((row) => row.id === req.user.id)
-      ) {
-        rows.push(await table.getRow({ id: req.user.id }));
-      }
-      result[table.name] = {
-        rows:
-          table.name !== "users"
-            ? rows
-            : rows.map(({ id, email, role_id, language, disabled }) => {
-                return { id, email, role_id, language, disabled };
-              }),
-      };
-    }
-    res.json(result);
-  })
-);
-
 const pickFields = (table, row) => {
   const result = {};
   for (const { name, type } of table.getFields()) {
+    if (name === "id") continue;
     if (type?.name === "Date") {
       result[name] = row[name] ? new Date(row[name]) : undefined;
     } else {
@@ -57,114 +20,65 @@ const pickFields = (table, row) => {
   return result;
 };
 
-const getChanges = (table, dbRow, appRow) => {
-  const changes = {};
-  for (const { name, type } of table.getFields()) {
-    if (name !== "id") {
-      const dbVal = dbRow[name];
-      const appVal = appRow[name];
-      let valHasChanged = false;
-      if (type?.name === "Date") {
-        valHasChanged = dbVal?.valueOf() !== appVal?.valueOf();
-      } else {
-        valHasChanged = dbVal !== appVal;
-      }
-      // TODO Float with decimal_places
-      if (valHasChanged) {
-        changes[name] = appRow[name];
-      }
-    }
-  }
-  return changes;
-};
-
-const allowUpdate = (table, row, user) => {
-  const role = user?.role_id || 100;
-  return table.min_role_write >= role || table.is_owner(user, row);
-};
-
-const allowInsert = (table, row, user) => {
+const allowInsert = (table, user) => {
   const role = user?.role_id || 100;
   return table.min_role_write >= role;
 };
 
-const syncRows = async (table, dbRows, appRows, user, dbClient) => {
-  const dbRowsLookup = {};
-  for (const row of dbRows) {
-    dbRowsLookup[row.id] = row;
-  }
-  const translatedIds = [];
-  for (const appRow of appRows.map((row) => pickFields(table, row))) {
-    if (!appRow.id) continue;
-    const dbRow = dbRowsLookup[appRow.id];
-    if (dbRow) {
-      const changes = getChanges(table, dbRow, appRow);
-      if (Object.keys(changes).length > 0 && allowUpdate(table, dbRow, user)) {
-        await db.update(table.name, changes, dbRow.id, { client: dbClient });
-      }
-    } else if (allowInsert(table, appRow, user)) {
-      const idFromApp = appRow.id;
-      delete appRow.id;
-      const newId = await db.insert(table.name, appRow, { client: dbClient });
-      if (newId !== idFromApp)
-        translatedIds.push({ from: idFromApp, to: newId });
-    } else {
-      getState().log(
-        3,
-        `Skipping id: '${appRow.id}' from app of table '${table.name}'`
-      );
-    }
-  }
-  return translatedIds;
+const throwWithCode = (message, code) => {
+  const err = new Error(message);
+  err.statusCode = code;
+  throw err;
 };
 
 /**
- * Sync the database to the state of an offline session with the mobile app
+ * insert the offline data uploaded by the mobile-app
  */
 router.post(
   "/table_data",
   error_catcher(async (req, res) => {
-    // TODO public user
     // TODO sqlite
     getState().log(
       4,
       `POST /sync/table_data user: '${req.user ? req.user.id : "public"}'`
     );
-    const role = req.user ? req.user.role_id : 100;
+    let aborted = false;
+    req.socket.on("close", () => {
+      aborted = true;
+    });
+    req.socket.on("timeout", () => {
+      aborted = true;
+    });
     const client = db.isSQLite ? db : await db.getClient();
-    const selectOpts = req.user ? { forUser: req.user } : { forPublic: true };
     try {
       await client.query("BEGIN");
       await client.query("SET CONSTRAINTS ALL DEFERRED");
-      const translateIds = {};
-      for (const [tblName, appRows] of Object.entries(req.body.data) || []) {
+      for (const [tblName, offlineRows] of Object.entries(req.body.data) ||
+        []) {
+        const table = Table.findOne({ name: tblName });
+        if (!table) throw new Error(`The table '${tblName}' does not exist.`);
+        if (!allowInsert(table, req.user))
+          throwWithCode(req.__("Not authorized"), 401);
         if (tblName !== "users") {
-          const table = Table.findOne({ name: tblName });
-          if (table) {
-            const dbRows =
-              role <= table.min_role_write
-                ? await table.getRows({}, selectOpts)
-                : (await table.getRows({}, selectOpts)).filter((row) =>
-                    table.is_owner(req.user, row)
-                  );
-            const translated = await syncRows(
-              table,
-              dbRows,
-              appRows,
-              req.user,
-              client
-            );
-            if (translated.length > 0) translateIds[tblName] = translated;
+          for (const newRow of offlineRows.map((row) =>
+            pickFields(table, row)
+          )) {
+            if (aborted) throw new Error("connection closed by client");
+            await db.insert(table.name, newRow, { client: client });
           }
         }
       }
+      if (aborted) throw new Error("connection closed by client");
       await client.query("COMMIT");
-      if (!db.isSQLite) await client.release(true);
-      res.json({ translateIds });
+      res.json({ success: true });
     } catch (error) {
       await client.query("ROLLBACK");
       getState().log(2, `POST /sync/table_data error: '${error.message}'`);
-      res.status(400).json({ error: error.message || error });
+      res
+        .status(error.statusCode || 400)
+        .json({ error: error.message || error });
+    } finally {
+      if (!db.isSQLite) await client.release(true);
     }
   })
 );


### PR DESCRIPTION
- removed the download of all user data
- in the offline mode, everything comes from that offline session, and the upload sends only that
- when the offline mode starts, the app redirects to the entry page, the offline mode starts automatically when you click something without internet
- the online mode dosent't start automatically, but you get a notification that its available
- added a switcher to change between online/offline and a button to clear all offline data
- clear the history of the back button when the mode changes, block the back button while uploading or deleting all offline data
- error page on first init has now links to reload the app
- optional axios timeout
- ROLLBACK upload when a server side 'timeoout' or client side 'close' happens