### PR TITLE
cordova version, empty strings, build clean option

### DIFF
--- a/packages/saltcorn-mobile-app/www/index.html
+++ b/packages/saltcorn-mobile-app/www/index.html
@@ -179,6 +179,7 @@
 
       // the app comes back from background
       const onResume = async () => {
+        if (!saltcorn?.data?.state) return;
         const state = saltcorn.data.state.getState();
         const mobileConfig = state.mobileConfig;
         if (mobileConfig?.allowOfflineMode) {

--- a/packages/saltcorn-mobile-app/www/js/utils/table_utils.js
+++ b/packages/saltcorn-mobile-app/www/js/utils/table_utils.js
@@ -34,7 +34,10 @@ async function updateScTables(tablesJSON, skipScPlugins = true) {
       // pick fields that really exist
       const insertRow = {};
       for (const safeField of existingFields) {
-        if (row[safeField]) insertRow[safeField] = row[safeField];
+        const fromRow = row[safeField];
+        if (fromRow !== null && fromRow !== undefined) {
+          insertRow[safeField] = fromRow;
+        }
       }
       await saltcorn.data.db.insert(table, insertRow);
     }

--- a/packages/saltcorn-mobile-builder/docker/Dockerfile
+++ b/packages/saltcorn-mobile-builder/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN android_sdk/cmdline-tools/latest/bin/sdkmanager "build-tools;30.0.3"
 RUN wget -q https://services.gradle.org/distributions/gradle-7.1.1-all.zip \
     && unzip gradle-7.1.1-all.zip -d /opt
 
-RUN npm install -g cordova
+RUN npm install -g cordova@11.1.0
 
 # create an empty project, the first init seems to take longer
 WORKDIR /init_project


### PR DESCRIPTION
- for now, don't use the newest cordova major version (12)
- keep empty string while updating the db
- added an option to build the 'cordova-builder' from scratch via the saltcorn cli