### PR TITLE
file saving in a remote query (for the signature-pad plugin)

### DIFF
--- a/packages/saltcorn-mobile-app/www/js/utils/iframe_view_utils.js
+++ b/packages/saltcorn-mobile-app/www/js/utils/iframe_view_utils.js
@@ -35,8 +35,8 @@ async function execNavbarLink(url) {
  * @param {*} urlSuffix
  * @returns
  */
-async function formSubmit(e, urlSuffix, viewname) {
-  e.submit();
+async function formSubmit(e, urlSuffix, viewname, noSubmitCb) {
+  if (!noSubmitCb) e.submit();
   const files = {};
   const urlParams = new URLSearchParams();
   for (const entry of new FormData(e).entries()) {


### PR DESCRIPTION
- the signature-pad plugin can be used in the mobile app
- moved the file save step into a remote query, so that it can run on the server
- won't work in the offline mode for now