### PR TITLE
dirCache for builder workflowSteps

### DIFF
--- a/packages/saltcorn-data/migrations/202304281224.js
+++ b/packages/saltcorn-data/migrations/202304281224.js
@@ -122,7 +122,7 @@ const js = async () => {
       iter_menu(state.getConfig("unrolled_menu_items", []))
     );
 
-  for (const folderFile of await File.allDirectories())
+  for (const folderFile of await File.allDirectories(true))
     for (const file of await File.find({ folder: folderFile.path_to_serve }))
       if (file.min_role_read && file.min_role_read > 1)
         await file.set_role(old_to_new_role(file.min_role_read));

--- a/packages/saltcorn-data/models/workflow.ts
+++ b/packages/saltcorn-data/models/workflow.ts
@@ -233,10 +233,17 @@ class Workflow implements AbstractWorkflow {
         ...(step.disablePreview ? {} : { previewURL: this.previewURL }),
       };
     } else if (step.builder) {
-      const options = {
-        ...(await applyAsync(step.builder, context)),
-        fonts: getState().fonts,
-      };
+      const File = (await import("./file")).default;
+      let options;
+      try {
+        await File.buildDirCache();
+        options = {
+          ...(await applyAsync(step.builder, context)),
+          fonts: getState().fonts,
+        };
+      } finally {
+        File.destroyDirCache();
+      }
       const Table = (await import("./table")).default;
       const table = Table.findOne(
         context.table_id

--- a/packages/server/routes/files.js
+++ b/packages/server/routes/files.js
@@ -90,7 +90,7 @@ router.get(
       for (const file of rows) {
         file.location = file.path_to_serve;
       }
-      const directories = await File.allDirectories();
+      const directories = await File.allDirectories(true);
       for (const file of directories) {
         file.location = file.path_to_serve;
       }

--- a/packages/server/routes/viewedit.js
+++ b/packages/server/routes/viewedit.js
@@ -22,6 +22,7 @@ const View = require("@saltcorn/data/models/view");
 const Workflow = require("@saltcorn/data/models/workflow");
 const User = require("@saltcorn/data/models/user");
 const Page = require("@saltcorn/data/models/page");
+const File = require("@saltcorn/data/models/file");
 const db = require("@saltcorn/data/db");
 const { sleep } = require("@saltcorn/data/utils");
 
@@ -580,6 +581,12 @@ router.get(
   "/config/:name",
   isAdmin,
   error_catcher(async (req, res) => {
+    req.socket.on("close", () => {
+      File.destroyDirCache();
+    });
+    req.socket.on("timeout", () => {
+      File.destroyDirCache();
+    });
     const { name } = req.params;
     const { step } = req.query;
     const [view] = await View.find({ name });


### PR DESCRIPTION
- added caching for allDirectories() so that you don't have to recalc it so often
- only for builder steps, and destroy it as soon as possible