### PR TITLE
mobile insert/update routes for the tabulator

### DIFF
--- a/packages/saltcorn-mobile-app/www/js/routes/api.js
+++ b/packages/saltcorn-mobile-app/www/js/routes/api.js
@@ -1,4 +1,4 @@
-/*global saltcorn, apiCall*/
+/*global saltcorn, apiCall, MobileRequest, offlineHelper*/
 
 // post/api/:tableName/:id
 const updateTableRow = async (context) => {
@@ -26,7 +26,14 @@ const updateTableRow = async (context) => {
     if (errors.length > 0) throw new Error(errors.join(", "));
     const ins_res = await table.tryUpdateRow(row, id, user);
     if (ins_res.error)
-      throw new Error(`Update ${table.name} error: ${ins_res.error}`);
+      throw new Error(`Update '${table.name}' error: ${ins_res.error}`);
+    if (
+      mobileConfig.isOfflineMode &&
+      !(await offlineHelper.getLastOfflineSession())
+    )
+      await offlineHelper.setOfflineSession({
+        offlineUser: mobileConfig.user_name,
+      });
     return { ins_res };
   } else {
     const response = await apiCall({
@@ -38,12 +45,61 @@ const updateTableRow = async (context) => {
   }
 };
 
+// post/api/:tableName
+const insertTableRow = async (context) => {
+  const { tableName } = context.params;
+  const table = saltcorn.data.models.Table.findOne({ name: tableName });
+  const mobileConfig = saltcorn.data.state.getState().mobileConfig;
+  const user = {
+    id: mobileConfig.user_id,
+    role_id: mobileConfig.role_id || 100,
+  };
+  if (!table) throw new Error(`The table '${tableName}' does not exist.`);
+  if (
+    mobileConfig.isOfflineMode ||
+    mobileConfig.localTableIds.indexOf(table.id) >= 0
+  ) {
+    const row = {};
+    for (const [k, v] of new URLSearchParams(context.query).entries()) {
+      row[k] = v;
+    }
+    const errors = await saltcorn.data.web_mobile_commons.prepare_insert_row(
+      row,
+      table.getFields()
+    );
+    if (errors.length > 0) throw new Error(errors.join(", "));
+    const ins_res = await table.tryInsertRow(row, user);
+    if (ins_res.error) {
+      throw new Error(`Insert '${table.name}' error: ${ins_res.error}`);
+    }
+    if (
+      mobileConfig.isOfflineMode &&
+      !(await offlineHelper.getLastOfflineSession())
+    )
+      await offlineHelper.setOfflineSession({
+        offlineUser: mobileConfig.user_name,
+      });
+    return { ins_res };
+  } else {
+    const response = await apiCall({
+      method: "POST",
+      path: `/api/${tableName}`,
+      body: context.query,
+    });
+    return response.data;
+  }
+};
+
 // get/api/:tableName
 const getTableRow = async (context) => {
   const { tableName } = context.params;
   const mobileConfig = saltcorn.data.state.getState().mobileConfig;
   if (mobileConfig.isOfflineMode) {
-    // TODO offline mode with tabulator
+    const table = saltcorn.data.models.Table.findOne({ name: tableName });
+    return await saltcorn.data.web_mobile_commons.get_rows({
+      table,
+      req: new MobileRequest(),
+    });
   } else {
     const queryObj = {};
     for (const [k, v] of new URLSearchParams(context.query).entries()) {

--- a/packages/saltcorn-mobile-app/www/js/routes/init.js
+++ b/packages/saltcorn-mobile-app/www/js/routes/init.js
@@ -1,4 +1,4 @@
-/*global postView, postViewRoute, getView, postToggleField, deleteRows, postPageAction, getPage, getLoginView, logoutAction, getSignupView, getErrorView, window, getSyncSettingsView, getAskDeleteOfflineData, getAskUploadNotEnded, updateTableRow, getTableRow */
+/*global postView, postViewRoute, getView, postToggleField, deleteRows, postPageAction, getPage, getLoginView, logoutAction, getSignupView, getErrorView, window, getSyncSettingsView, getAskDeleteOfflineData, getAskUploadNotEnded, updateTableRow, getTableRow, insertTableRow */
 // TODO module namespacese
 
 const initRoutes = async () => {
@@ -18,6 +18,10 @@ const initRoutes = async () => {
     {
       path: "post/api/:tableName/:id",
       action: updateTableRow,
+    },
+    {
+      path: "post/api/:tableName/",
+      action: insertTableRow,
     },
     {
       path: "get/api/:tableName",

--- a/packages/saltcorn-mobile-builder/mobile-builder.ts
+++ b/packages/saltcorn-mobile-builder/mobile-builder.ts
@@ -10,7 +10,7 @@ import {
   buildTablesFile,
   copySbadmin2Deps,
   copySiteLogo,
-  copyStaticAssets,
+  copyServerFiles,
   copyTranslationFiles,
   createSqliteDb,
   writeCfgFile,
@@ -117,7 +117,7 @@ export class MobileBuilder {
     if (this.appName) await setAppName(this.buildDir, this.appName);
     if (this.appVersion) await setAppVersion(this.buildDir, this.appVersion);
     if (this.appIcon) await prepareAppIcon(this.buildDir, this.appIcon);
-    copyStaticAssets(this.buildDir);
+    copyServerFiles(this.buildDir);
     copySbadmin2Deps(this.buildDir);
     await copySiteLogo(this.buildDir);
     copyTranslationFiles(this.buildDir);

--- a/packages/saltcorn-mobile-builder/utils/common-build-utils.ts
+++ b/packages/saltcorn-mobile-builder/utils/common-build-utils.ts
@@ -20,15 +20,16 @@ import { getState } from "@saltcorn/data/db/state";
  * copy files from 'server/public' into the www folder (with a version_tag prefix)
  * @param buildDir directory where the app will be build
  */
-export function copyStaticAssets(buildDir: string) {
+export function copyServerFiles(buildDir: string) {
   const wwwDir = join(buildDir, "www");
+  // assets
   const assetsDst = join(wwwDir, "static_assets", db.connectObj.version_tag);
   if (!existsSync(assetsDst)) {
     mkdirSync(assetsDst, { recursive: true });
   }
   const serverRoot = join(require.resolve("@saltcorn/server"), "..");
   const srcPrefix = join(serverRoot, "public");
-  const srcFiles = [
+  const srcAssests = [
     "jquery-3.6.0.min.js",
     "saltcorn-common.js",
     "saltcorn.js",
@@ -36,9 +37,21 @@ export function copyStaticAssets(buildDir: string) {
     "codemirror.js",
     "codemirror.css",
     "socket.io.min.js",
+    "flatpickr.min.css",
+    "gridedit.js",
+    "flatpickr.min.js",
   ];
-  for (const srcFile of srcFiles) {
+  for (const srcFile of srcAssests) {
     copySync(join(srcPrefix, srcFile), join(assetsDst, srcFile));
+  }
+  // publics
+  const srcs = [
+    "flatpickr.min.css",
+    "flatpickr.min.js",
+    "gridedit.js"
+  ];
+  for (const srcFile of srcs) {
+    copySync(join(srcPrefix, srcFile), join(wwwDir, srcFile));
   }
 }
 

--- a/packages/server/public/gridedit.js
+++ b/packages/server/public/gridedit.js
@@ -4,10 +4,11 @@ function showHideCol(nm, e) {
 }
 
 function lookupIntToString(cell, formatterParams, onRendered) {
-  const cellVal = cell.getValue()
-  const val = typeof cellVal === "object" && cellVal !== null
-    ? `${cellVal.id}`
-    : `${cellVal}`;
+  const cellVal = cell.getValue();
+  const val =
+    typeof cellVal === "object" && cellVal !== null
+      ? `${cellVal.id}`
+      : `${cellVal}`;
   const res = formatterParams.values[val];
   return res;
 }
@@ -19,10 +20,11 @@ function deleteIcon() {
 function flatpickerEditor(cell, onRendered, success, cancel, editorParams) {
   var input = $("<input type='text'/>");
   const dayOnly = editorParams && editorParams.dayOnly;
-  let defaultDate = cell.getValue()
+  let defaultDate = cell.getValue();
 
-  if (!defaultDate) defaultDate = new Date()
+  if (!defaultDate) defaultDate = new Date();
   input.flatpickr({
+    disableMobile: true, // the native picker has problems combined with tabulator
     enableTime: !dayOnly,
     dateFormat: dayOnly ? "Y-m-d" : "Z",
     time_24hr: true,
@@ -30,7 +32,7 @@ function flatpickerEditor(cell, onRendered, success, cancel, editorParams) {
     defaultDate,
     onClose: function (selectedDates, dateStr, instance) {
       evt = window.event;
-      var isEscape = false;
+      var isEscape = false; 
       if ("key" in evt) {
         isEscape = evt.key === "Escape" || evt.key === "Esc";
       } else {
@@ -156,7 +158,8 @@ function delete_tabulator_row(e, cell) {
   if (def && def.formatterParams && def.formatterParams.confirm) {
     if (!confirm("Are you sure you want to delete this row?")) return;
   }
-  const tableName = def?.formatterParams?.tableName || window.tabulator_table_name
+  const tableName =
+    def?.formatterParams?.tableName || window.tabulator_table_name;
 
   const row = cell.getRow().getData();
   if (!row.id) {

--- a/packages/server/routes/sync.js
+++ b/packages/server/routes/sync.js
@@ -9,8 +9,9 @@ module.exports = router;
 
 const pickFields = (table, row) => {
   const result = {};
-  for (const { name, type } of table.getFields()) {
-    if (name === "id") continue;
+  const fields = table.getFields();
+  for (const { name, type, calculated } of table.getFields()) {
+    if (name === "id" || calculated) continue;
     if (type?.name === "Date") {
       result[name] = row[name] ? new Date(row[name]) : undefined;
     } else {


### PR DESCRIPTION
- moved parts from the insert/update service into web-mobile-common and implemented the mobile part (with offline mode support)
- in the mobile web site and in the app don't show the native picker for tabulator date columns
- don't upload calculated fields into the db