### PR TITLE
Mobile build tests

### DIFF
--- a/deploy/vagrant-test-install/debian11-mobile/Vagrantfile
+++ b/deploy/vagrant-test-install/debian11-mobile/Vagrantfile
@@ -23,8 +23,8 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "shell", inline: <<-SHELL
     set -e
-    OK | sudo DEBIAN_FRONTEND=noninteractive apt update -yq
-    OK | sudo DEBIAN_FRONTEND=noninteractive apt upgrade -qqy
+    sudo DEBIAN_FRONTEND=noninteractive apt update -yq
+    sudo DEBIAN_FRONTEND=noninteractive apt upgrade -qqy
 
     sudo apt-get -y install libpulse0 pulseaudio libxcursor-dev libxdamage-dev
     sudo apt-get -y install qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils
@@ -39,19 +39,15 @@ Vagrant.configure("2") do |config|
     sudo -u saltcorn wget https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip
     sudo -u saltcorn unzip commandlinetools-linux-8512546_latest.zip
     sudo -u saltcorn mkdir /home/saltcorn/android_sdk
-    yes | sudo -u saltcorn cmdline-tools/bin/sdkmanager --sdk_root=/home/saltcorn/android_sdk --install "cmdline-tools;latest"
-    sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/latest/bin/sdkmanager --list
-    sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/latest/bin/sdkmanager "platforms;android-11"
-    sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/latest/bin/sdkmanager "build-tools;30.0.3"
+    yes | sudo -u saltcorn cmdline-tools/bin/sdkmanager --sdk_root=/home/saltcorn/android_sdk --install "cmdline-tools;10.0"
+    sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/10.0/bin/sdkmanager --list
+    sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/10.0/bin/sdkmanager "platforms;android-11"
+    sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/10.0/bin/sdkmanager "build-tools;30.0.3"
 
     sudo adduser saltcorn kvm
-    yes | sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/latest/bin/sdkmanager "system-images;android-32;google_apis;x86_64"
-    echo "no" | sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/latest/bin/avdmanager create avd --force -n test -k "system-images;android-32;google_apis;x86_64" --device "pixel_xl"
+    yes | sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/10.0/bin/sdkmanager "system-images;android-32;google_apis;x86_64"
+    echo "no" | sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/10.0/bin/avdmanager create avd --force -n test -k "system-images;android-32;google_apis;x86_64" --device "pixel_xl"
     
-    # start emulator
-    sudo -u saltcorn /home/saltcorn/android_sdk/emulator/emulator -avd test -memory 3072 -no-audio -no-window -no-boot-anim -accel on -gpu auto -no-snapshot-load &
-    sudo -u saltcorn /home/saltcorn/android_sdk/platform-tools/adb wait-for-device
-
     npm install -g npm@9.2.0
 
     sudo -u saltcorn wget -q https://services.gradle.org/distributions/gradle-7.1.1-all.zip
@@ -63,17 +59,24 @@ Vagrant.configure("2") do |config|
     export GRADLE_HOME=/opt/gradle-7.1.1
     export PATH=$PATH:/opt/gradle-7.1.1/bin
     export CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL=file\:/home/saltcorn/gradle-7.1.1-all.zip
+    export SALTCORN_NWORKERS=1
 
     sudo -u saltcorn /home/saltcorn/.local/bin/saltcorn create-user -e user@foo.com -r admin -p foobarbarfoo
     sudo -u saltcorn /home/saltcorn/.local/bin/saltcorn install-pack -n "Address book"
 
     echo "build apk"
     sudo --preserve-env=JAVA_HOME,ANDROID_SDK_ROOT,GRADLE_HOME,PATH,CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL -u saltcorn /home/saltcorn/.local/bin/saltcorn build-app -c /home/saltcorn -u "user@foo.com" -p "android" -s "http://10.0.2.2:3000" -b "/home/saltcorn/build_dir" -e "EditMeeting"
-    sudo -u saltcorn /home/saltcorn/.local/bin/saltcorn serve -p 3000 &
+    sudo --preserve-env=SALTCORN_NWORKERS -u saltcorn /home/saltcorn/.local/bin/saltcorn serve -p 3000 &
     set +e
+
+    echo "start emulator"
+    sudo -u saltcorn /home/saltcorn/android_sdk/emulator/emulator -avd test -memory 3072 -no-audio -no-window -no-boot-anim -accel on -gpu auto -no-snapshot-load &
+    sudo -u saltcorn /home/saltcorn/android_sdk/platform-tools/adb wait-for-device
+    sleep 500
 
     echo "install apk"
     sudo -u saltcorn /home/saltcorn/android_sdk/platform-tools/adb -s emulator-5554 install /home/saltcorn/app-debug.apk
+    sleep 20
     
     echo "start app"
     START_TRY=0

--- a/deploy/vagrant-test-install/debian11-mobile/Vagrantfile
+++ b/deploy/vagrant-test-install/debian11-mobile/Vagrantfile
@@ -7,23 +7,31 @@
 # you're doing.
 Vagrant.configure("2") do |config|
 
-  config.vm.box = "debian/bullseye64"
+  config.vm.box = "generic/debian11"
 
   config.ssh.forward_agent = true
 
   config.ssh.insert_key = false
 
+  config.vm.provision "file", source: "../../../packages/saltcorn-mobile-builder/appium_tests/package.json", destination: "$HOME/tests/package.json"
+  config.vm.provision "file", source: "../../../packages/saltcorn-mobile-builder/appium_tests/ui.test.js", destination: "$HOME/tests/ui.test.js"
 
-
-  config.vm.provider "virtualbox" do |vb|  
+  config.vm.provider "libvirt" do |vb|  
     # Customize the amount of memory on the VM:
-    vb.memory = "4096"
+    vb.memory = "8192"
   end
 
   config.vm.provision "shell", inline: <<-SHELL
+    set -e
+    OK | sudo DEBIAN_FRONTEND=noninteractive apt update -yq
+    OK | sudo DEBIAN_FRONTEND=noninteractive apt upgrade -qqy
+
+    sudo apt-get -y install libpulse0 pulseaudio libxcursor-dev libxdamage-dev
+    sudo apt-get -y install qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils
+
     wget -qO - https://deb.nodesource.com/setup_16.x | bash -
     apt-get install -qqy nodejs
-    sudo -iu vagrant npx -y saltcorn-install -y
+    sudo -iu vagrant npx -y saltcorn-install -s -y
 
     apt update && apt install -y wget unzip openjdk-11-jdk openjdk-11-demo openjdk-11-doc openjdk-11-jre-headless openjdk-11-source
     
@@ -35,6 +43,14 @@ Vagrant.configure("2") do |config|
     sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/latest/bin/sdkmanager --list
     sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/latest/bin/sdkmanager "platforms;android-11"
     sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/latest/bin/sdkmanager "build-tools;30.0.3"
+
+    sudo adduser saltcorn kvm
+    yes | sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/latest/bin/sdkmanager "system-images;android-32;google_apis;x86_64"
+    echo "no" | sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/latest/bin/avdmanager create avd --force -n test -k "system-images;android-32;google_apis;x86_64" --device "pixel_xl"
+    
+    # start emulator
+    sudo -u saltcorn /home/saltcorn/android_sdk/emulator/emulator -avd test -memory 3072 -no-audio -no-window -no-boot-anim -accel on -gpu auto -no-snapshot-load &
+    sudo -u saltcorn /home/saltcorn/android_sdk/platform-tools/adb wait-for-device
 
     npm install -g npm@9.2.0
 
@@ -48,7 +64,50 @@ Vagrant.configure("2") do |config|
     export PATH=$PATH:/opt/gradle-7.1.1/bin
     export CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL=file\:/home/saltcorn/gradle-7.1.1-all.zip
 
+    sudo -u saltcorn /home/saltcorn/.local/bin/saltcorn create-user -e user@foo.com -r admin -p foobarbarfoo
     sudo -u saltcorn /home/saltcorn/.local/bin/saltcorn install-pack -n "Address book"
-    sudo --preserve-env=JAVA_HOME,ANDROID_SDK_ROOT,GRADLE_HOME,PATH,CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL -u saltcorn /home/saltcorn/.local/bin/saltcorn build-app -p "android" -s "http://10.0.2.2" -b "/home/saltcorn/build_dir" -e "EditPerson"
+
+    echo "build apk"
+    sudo --preserve-env=JAVA_HOME,ANDROID_SDK_ROOT,GRADLE_HOME,PATH,CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL -u saltcorn /home/saltcorn/.local/bin/saltcorn build-app -c /home/saltcorn -u "user@foo.com" -p "android" -s "http://10.0.2.2:3000" -b "/home/saltcorn/build_dir" -e "EditMeeting"
+    sudo -u saltcorn /home/saltcorn/.local/bin/saltcorn serve -p 3000 &
+    set +e
+
+    echo "install apk"
+    sudo -u saltcorn /home/saltcorn/android_sdk/platform-tools/adb -s emulator-5554 install /home/saltcorn/app-debug.apk
+    
+    echo "start app"
+    START_TRY=0
+    sudo -u saltcorn /home/saltcorn/android_sdk/platform-tools/adb shell am start -n saltcorn.mobile.app/.MainActivity
+    LINES=$(sudo -u saltcorn /home/saltcorn/android_sdk/platform-tools/adb shell ps | grep saltcorn.mobile.app | wc -l)
+    while [ $LINES -eq 0 ] && [ $START_TRY -lt 50 ]; do
+      let START_TRY++
+      sleep 5
+      echo "re-try start app"
+      sudo -u saltcorn /home/saltcorn/android_sdk/platform-tools/adb shell am start -n saltcorn.mobile.app/.MainActivity
+      LINES=$(sudo -u saltcorn /home/saltcorn/android_sdk/platform-tools/adb shell ps | grep saltcorn.mobile.app | wc -l)
+    done
+
+    if [ $LINES -eq 1 ]; then
+      echo "success"
+    else
+      echo "error: Unable to start the app"
+      exit 1
+    fi
+
+    echo "prepare appium"
+    cd /home/saltcorn
+    sudo npm install -g appium@2.0.0-beta.40
+    sudo npm install -g appium-chromedriver
+    appium driver install uiautomator2
+    appium --allow-insecure chromedriver_autodownload &
+    sleep 10
+
+    echo "run tests"
+    cd /home/vagrant/tests
+    npm install
+    npm run test
+    
+    set -e
+    npm run test
   SHELL
 end

--- a/deploy/vagrant-test-install/test_all.sh
+++ b/deploy/vagrant-test-install/test_all.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-# machines to run with libvirt
-libvirts=("ubuntu2004-mobile/")
+# to run with libvirt
+libvirts=("ubuntu2004-mobile/" "debian11-mobile/")
 
 for d in */ ; do
     echo ""

--- a/deploy/vagrant-test-install/test_all.sh
+++ b/deploy/vagrant-test-install/test_all.sh
@@ -2,13 +2,20 @@
 
 set -ex
 
+# machines to run with libvirt
+libvirts=("ubuntu2004-mobile/")
+
 for d in */ ; do
     echo ""
     echo "-----------------------------------------"
     echo "Now testing $d"
     echo "-----------------------------------------"
     pushd "$d"
-    vagrant up
+    if [[ "${libvirts[@]}" =~ "$d" ]]; then
+      vagrant up --provider=libvirt
+    else
+      vagrant up
+    fi
     vagrant destroy -f
     popd
 done

--- a/deploy/vagrant-test-install/ubuntu2004-mobile/Vagrantfile
+++ b/deploy/vagrant-test-install/ubuntu2004-mobile/Vagrantfile
@@ -19,6 +19,9 @@ Vagrant.configure("2") do |config|
     vb.memory = "8192"
   end
 
+  config.vm.provision "file", source: "../../../packages/saltcorn-mobile-builder/appium_tests/package.json", destination: "$HOME/tests/package.json"
+  config.vm.provision "file", source: "../../../packages/saltcorn-mobile-builder/appium_tests/ui.test.js", destination: "$HOME/tests/ui.test.js"
+
   config.vm.provision "shell", inline: <<-SHELL
     set -e
     sudo apt update -q
@@ -47,7 +50,7 @@ Vagrant.configure("2") do |config|
     echo "no" | sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/latest/bin/avdmanager create avd --force -n test -k "system-images;android-32;google_apis;x86_64" --device "pixel_xl"
     
     # start emulator
-    sudo -u saltcorn /home/saltcorn/android_sdk/emulator/emulator -avd test -memory 3072 -partition-size 8192 -no-audio -no-window -no-boot-anim -accel on -gpu swiftshader_indirect -no-snapshot-load &
+    sudo -u saltcorn /home/saltcorn/android_sdk/emulator/emulator -avd test -memory 3072 -no-audio -no-window -no-boot-anim -accel on -gpu auto -no-snapshot-load &
     sudo -u saltcorn /home/saltcorn/android_sdk/platform-tools/adb wait-for-device
 
     npm install -g npm@9.2.0
@@ -66,8 +69,8 @@ Vagrant.configure("2") do |config|
     sudo -u saltcorn /home/saltcorn/.local/bin/saltcorn install-pack -n "Address book"
     
     echo "build apk"
-    sudo --preserve-env=JAVA_HOME,ANDROID_SDK_ROOT,GRADLE_HOME,PATH,CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL -u saltcorn /home/saltcorn/.local/bin/saltcorn build-app -c /home/saltcorn -u "user@foo.com" -p "android" -s "http://10.0.2.2" -b "/home/saltcorn/build_dir" -e "EditPerson"
-    sudo -u saltcorn /home/saltcorn/.local/bin/saltcorn serve &
+    sudo --preserve-env=JAVA_HOME,ANDROID_SDK_ROOT,GRADLE_HOME,PATH,CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL -u saltcorn /home/saltcorn/.local/bin/saltcorn build-app -c /home/saltcorn -u "user@foo.com" -p "android" -s "http://10.0.2.2:3000" -b "/home/saltcorn/build_dir" -e "EditMeeting"
+    sudo -u saltcorn /home/saltcorn/.local/bin/saltcorn serve -p 3000 &
     set +e
 
     echo "install apk"
@@ -87,11 +90,24 @@ Vagrant.configure("2") do |config|
 
     if [ $LINES -eq 1 ]; then
       echo "success"
-      exit 0
     else
       echo "error: Unable to start the app"
       exit 1
     fi
+
+    echo "prepare appium"
+    cd /home/saltcorn
+    sudo npm install -g appium@2.0.0-beta.40
+    sudo npm install -g appium-chromedriver
+    appium driver install uiautomator2
+    appium --allow-insecure chromedriver_autodownload &
+    sleep 10
+
+    set -e
+    echo "run tests"
+    cd /home/vagrant/tests
+    npm install
+    npm run test
 
     SHELL
   end

--- a/deploy/vagrant-test-install/ubuntu2004-mobile/Vagrantfile
+++ b/deploy/vagrant-test-install/ubuntu2004-mobile/Vagrantfile
@@ -40,19 +40,15 @@ Vagrant.configure("2") do |config|
     sudo -u saltcorn wget https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip
     sudo -u saltcorn unzip commandlinetools-linux-8512546_latest.zip
     sudo -u saltcorn mkdir /home/saltcorn/android_sdk
-    yes | sudo -u saltcorn cmdline-tools/bin/sdkmanager --sdk_root=/home/saltcorn/android_sdk --install "cmdline-tools;latest"
-    sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/latest/bin/sdkmanager --list
-    sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/latest/bin/sdkmanager "platforms;android-11"
-    sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/latest/bin/sdkmanager "build-tools;30.0.3"
+    yes | sudo -u saltcorn cmdline-tools/bin/sdkmanager --sdk_root=/home/saltcorn/android_sdk --install "cmdline-tools;10.0"
+    sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/10.0/bin/sdkmanager --list
+    sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/10.0/bin/sdkmanager "platforms;android-11"
+    sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/10.0/bin/sdkmanager "build-tools;30.0.3"
 
     sudo adduser saltcorn kvm
-    yes | sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/latest/bin/sdkmanager "system-images;android-32;google_apis;x86_64"
-    echo "no" | sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/latest/bin/avdmanager create avd --force -n test -k "system-images;android-32;google_apis;x86_64" --device "pixel_xl"
+    yes | sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/10.0/bin/sdkmanager "system-images;android-32;google_apis;x86_64"
+    echo "no" | sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/10.0/bin/avdmanager create avd --force -n test -k "system-images;android-32;google_apis;x86_64" --device "pixel_xl"
     
-    # start emulator
-    sudo -u saltcorn /home/saltcorn/android_sdk/emulator/emulator -avd test -memory 3072 -no-audio -no-window -no-boot-anim -accel on -gpu auto -no-snapshot-load &
-    sudo -u saltcorn /home/saltcorn/android_sdk/platform-tools/adb wait-for-device
-
     npm install -g npm@9.2.0
 
     sudo -u saltcorn wget -q https://services.gradle.org/distributions/gradle-7.1.1-all.zip
@@ -64,18 +60,25 @@ Vagrant.configure("2") do |config|
     export GRADLE_HOME=/opt/gradle-7.1.1
     export PATH=$PATH:/opt/gradle-7.1.1/bin
     export CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL=file\:/home/saltcorn/gradle-7.1.1-all.zip
+    export SALTCORN_NWORKERS=1
 
     sudo -u saltcorn /home/saltcorn/.local/bin/saltcorn create-user -e user@foo.com -r admin -p foobarbarfoo
     sudo -u saltcorn /home/saltcorn/.local/bin/saltcorn install-pack -n "Address book"
     
     echo "build apk"
     sudo --preserve-env=JAVA_HOME,ANDROID_SDK_ROOT,GRADLE_HOME,PATH,CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL -u saltcorn /home/saltcorn/.local/bin/saltcorn build-app -c /home/saltcorn -u "user@foo.com" -p "android" -s "http://10.0.2.2:3000" -b "/home/saltcorn/build_dir" -e "EditMeeting"
-    sudo -u saltcorn /home/saltcorn/.local/bin/saltcorn serve -p 3000 &
+    sudo --preserve-env=SALTCORN_NWORKERS -u saltcorn /home/saltcorn/.local/bin/saltcorn serve -p 3000 &
     set +e
+
+    echo "start emulator"
+    sudo -u saltcorn /home/saltcorn/android_sdk/emulator/emulator -avd test -memory 3072 -partition-size 2047 -no-audio -no-window -no-boot-anim -accel on -gpu auto -no-snapshot-load &
+    sudo -u saltcorn /home/saltcorn/android_sdk/platform-tools/adb wait-for-device
+    sleep 500
 
     echo "install apk"
     sudo -u saltcorn /home/saltcorn/android_sdk/platform-tools/adb -s emulator-5554 install /home/saltcorn/app-debug.apk
-    
+    sleep 20
+
     echo "start app"
     START_TRY=0
     sudo -u saltcorn /home/saltcorn/android_sdk/platform-tools/adb shell am start -n saltcorn.mobile.app/.MainActivity

--- a/deploy/vagrant-test-install/ubuntu2004-mobile/Vagrantfile
+++ b/deploy/vagrant-test-install/ubuntu2004-mobile/Vagrantfile
@@ -7,23 +7,25 @@
 # you're doing.
 Vagrant.configure("2") do |config|
 
-  config.vm.box = "ubuntu/focal64"
+  config.vm.box = "generic/ubuntu2004"
 
   config.ssh.forward_agent = true
 
   config.ssh.insert_key = false
 
 
-  config.vm.provider "virtualbox" do |vb|  
+  config.vm.provider "libvirt" do |vb|  
     # Customize the amount of memory on the VM:
-    vb.memory = "4096"
+    vb.memory = "8192"
   end
-
 
   config.vm.provision "shell", inline: <<-SHELL
     set -e
     sudo apt update -q
     sudo apt upgrade -qqy
+
+    sudo apt-get -y install libpulse0 pulseaudio libxcursor-dev libxdamage-dev
+    sudo apt-get -y install qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils
 
     wget -qO - https://deb.nodesource.com/setup_16.x | bash -
     apt-get install -qqy nodejs
@@ -40,6 +42,14 @@ Vagrant.configure("2") do |config|
     sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/latest/bin/sdkmanager "platforms;android-11"
     sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/latest/bin/sdkmanager "build-tools;30.0.3"
 
+    sudo adduser saltcorn kvm
+    yes | sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/latest/bin/sdkmanager "system-images;android-32;google_apis;x86_64"
+    echo "no" | sudo -u saltcorn /home/saltcorn/android_sdk/cmdline-tools/latest/bin/avdmanager create avd --force -n test -k "system-images;android-32;google_apis;x86_64" --device "pixel_xl"
+    
+    # start emulator
+    sudo -u saltcorn /home/saltcorn/android_sdk/emulator/emulator -avd test -memory 3072 -partition-size 8192 -no-audio -no-window -no-boot-anim -accel on -gpu swiftshader_indirect -no-snapshot-load &
+    sudo -u saltcorn /home/saltcorn/android_sdk/platform-tools/adb wait-for-device
+
     npm install -g npm@9.2.0
 
     sudo -u saltcorn wget -q https://services.gradle.org/distributions/gradle-7.1.1-all.zip
@@ -52,7 +62,36 @@ Vagrant.configure("2") do |config|
     export PATH=$PATH:/opt/gradle-7.1.1/bin
     export CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL=file\:/home/saltcorn/gradle-7.1.1-all.zip
 
+    sudo -u saltcorn /home/saltcorn/.local/bin/saltcorn create-user -e user@foo.com -r admin -p foobarbarfoo
     sudo -u saltcorn /home/saltcorn/.local/bin/saltcorn install-pack -n "Address book"
-    sudo --preserve-env=JAVA_HOME,ANDROID_SDK_ROOT,GRADLE_HOME,PATH,CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL -u saltcorn /home/saltcorn/.local/bin/saltcorn build-app -p "android" -s "http://10.0.2.2" -b "/home/saltcorn/build_dir" -e "EditPerson"
-  SHELL
-end
+    
+    echo "build apk"
+    sudo --preserve-env=JAVA_HOME,ANDROID_SDK_ROOT,GRADLE_HOME,PATH,CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL -u saltcorn /home/saltcorn/.local/bin/saltcorn build-app -c /home/saltcorn -u "user@foo.com" -p "android" -s "http://10.0.2.2" -b "/home/saltcorn/build_dir" -e "EditPerson"
+    sudo -u saltcorn /home/saltcorn/.local/bin/saltcorn serve &
+    set +e
+
+    echo "install apk"
+    sudo -u saltcorn /home/saltcorn/android_sdk/platform-tools/adb -s emulator-5554 install /home/saltcorn/app-debug.apk
+    
+    echo "start app"
+    START_TRY=0
+    sudo -u saltcorn /home/saltcorn/android_sdk/platform-tools/adb shell am start -n saltcorn.mobile.app/.MainActivity
+    LINES=$(sudo -u saltcorn /home/saltcorn/android_sdk/platform-tools/adb shell ps | grep saltcorn.mobile.app | wc -l)
+    while [ $LINES -eq 0 ] && [ $START_TRY -lt 50 ]; do
+      let START_TRY++
+      sleep 5
+      echo "re-try start app"
+      sudo -u saltcorn /home/saltcorn/android_sdk/platform-tools/adb shell am start -n saltcorn.mobile.app/.MainActivity
+      LINES=$(sudo -u saltcorn /home/saltcorn/android_sdk/platform-tools/adb shell ps | grep saltcorn.mobile.app | wc -l)
+    done
+
+    if [ $LINES -eq 1 ]; then
+      echo "success"
+      exit 0
+    else
+      echo "error: Unable to start the app"
+      exit 1
+    fi
+
+    SHELL
+  end

--- a/packages/saltcorn-mobile-builder/appium_tests/package.json
+++ b/packages/saltcorn-mobile-builder/appium_tests/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "appium_tests",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "appium": "^2.0.0-beta.53",
+    "webdriverio": "^8.11.2",
+    "jest": "^29.2.1"
+  },
+  "jest": {
+    "testEnvironment": "jest-environment-node",
+    "transform": {}
+  }
+}

--- a/packages/saltcorn-mobile-builder/appium_tests/ui.test.js
+++ b/packages/saltcorn-mobile-builder/appium_tests/ui.test.js
@@ -1,0 +1,47 @@
+const { remote } = require("webdriverio");
+
+const capabilities = {
+  platformName: "Android",
+  "appium:automationName": "UiAutomator2",
+  "appium:deviceName": "Android",
+  "appium:appPackage": "saltcorn.mobile.app",
+  "appium:appActivity": ".MainActivity",
+};
+
+const wdOpts = {
+  host: process.env.APPIUM_HOST || "localhost",
+  port: 4723,
+  logLevel: "info",
+  capabilities,
+};
+
+jest.setTimeout(4000000);
+
+let driver;
+beforeAll(async () => {
+  driver = await remote(wdOpts);
+  await driver.switchContext("WEBVIEW_saltcorn.mobile.app");
+  await driver.pause(10000);
+});
+
+afterAll(async () => {
+  await driver.deleteSession();
+});
+
+describe("appium", () => {
+  it("basic test", async () => {
+    if (driver) {
+      const iframe = await driver.$("iframe");
+      await driver.switchToFrame(iframe);
+      await driver.pause(10000);
+      console.log(await driver.getLogs("browser"));
+      const emailInput = await driver.$('input[name="email"]');
+      await emailInput.setValue("user@foo.com");
+      const passwordInput = await driver.$('input[name="password"]');
+      await passwordInput.setValue("foobarbarfoo");
+      const button = await driver.$("button");
+      await button.click();
+      await driver.pause(10000);   
+    }
+  });
+});

--- a/packages/saltcorn-mobile-builder/package.json
+++ b/packages/saltcorn-mobile-builder/package.json
@@ -6,7 +6,7 @@
   "version": "0.8.7-beta.3",
   "author": "Christian Hugo",
   "scripts": {
-    "test": "jest tests --runInBand",
+    "test": "jest ./tests/ --runInBand",
     "build": "webpack --mode development",
     "postinstall": "node ./docker/post-installer.js"
   },

--- a/packages/saltcorn-mobile-builder/package.json
+++ b/packages/saltcorn-mobile-builder/package.json
@@ -6,6 +6,7 @@
   "version": "0.8.7-beta.3",
   "author": "Christian Hugo",
   "scripts": {
+    "test": "jest tests --runInBand",
     "build": "webpack --mode development",
     "postinstall": "node ./docker/post-installer.js"
   },
@@ -26,7 +27,22 @@
   },
   "devDependencies": {
     "@types/node": "^16.11.7",
-    "@types/xml2js": "0.4.11"
+    "@types/xml2js": "0.4.11",
+    "jest": "^27.1.0",
+    "ts-jest": "^27.1.0"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "modulePathIgnorePatterns": [
+      ".*\\.js$"
+    ],
+    "moduleNameMapper": {
+      "@saltcorn/sqlite/(.*)": "@saltcorn/sqlite/dist/$1",
+      "@saltcorn/db-common/(.*)": "@saltcorn/db-common/dist/$1",
+      "@saltcorn/data/(.*)": "@saltcorn/data/dist/$1",
+      "@saltcorn/types/(.*)": "@saltcorn/types/dist/$1"
+    }
   },
   "main": "./dist/index.js",
   "exports": {

--- a/packages/saltcorn-mobile-builder/tests/webpack.test.ts
+++ b/packages/saltcorn-mobile-builder/tests/webpack.test.ts
@@ -1,0 +1,79 @@
+import db from "@saltcorn/data/db/index";
+import { spawnSync } from "child_process";
+import Plugin from "@saltcorn/data/models/plugin";
+import { assertIsSet } from "@saltcorn/data/tests/assertions";
+import { rmSync, existsSync } from "fs";
+import { join } from "path";
+const load_plugins = require("@saltcorn/server/load_plugins");
+
+afterAll(db.close);
+
+jest.setTimeout(30000);
+
+describe("webpack build", () => {
+  const bundleDir = join(__dirname, "bundle");
+  it("without plugins", async () => {
+    if (existsSync(bundleDir))
+      rmSync(bundleDir, { recursive: true, force: true });
+    const result = spawnSync(
+      "npm",
+      ["run", "build", "--", "--env", `output=${__dirname}`],
+      {
+        cwd: __dirname,
+      }
+    );
+    const output = result.output.toString();
+    expect(result.status).toBe(0);
+    expect(output.indexOf(" compiled with ")).toBeGreaterThan(-1);
+    for (const expected of [
+      bundleDir,
+      join(bundleDir, "base_plugin.bundle.js"),
+      join(bundleDir, "common_chunks.bundle.js"),
+      join(bundleDir, "data.bundle.js"),
+      join(bundleDir, "markup.bundle.js"),
+      join(bundleDir, "sbadmin2.bundle.js"),
+    ]) {
+      expect(existsSync(expected)).toBe(true);
+    }
+  });
+
+  it("with plugins", async () => {
+    const anyBootstrapTheme = await Plugin.store_by_name("any-bootstrap-theme");
+    assertIsSet(anyBootstrapTheme);
+    delete anyBootstrapTheme.id;
+    await load_plugins.loadAndSaveNewPlugin(anyBootstrapTheme);
+
+    const tabulator = await Plugin.store_by_name("tabulator");
+    assertIsSet(tabulator);
+    delete tabulator.id;
+    await load_plugins.loadAndSaveNewPlugin(tabulator);
+
+    if (existsSync(bundleDir))
+      rmSync(bundleDir, { recursive: true, force: true });
+    const result = spawnSync(
+      "npm",
+      [
+        "run",
+        "build",
+        "--",
+        "--env",
+        `plugins=${JSON.stringify([anyBootstrapTheme, tabulator])}`,
+        "--env",
+        `output=${__dirname}`,
+      ],
+      {
+        cwd: __dirname,
+      }
+    );
+    const output = result.output.toString();
+    expect(result.status).toBe(0);
+    expect(output.indexOf(" compiled with ")).toBeGreaterThan(-1);
+    for (const expected of [
+      bundleDir,
+      join(bundleDir, "any-bootstrap-theme.js"),
+      join(bundleDir, "tabulator.bundle.js"),
+    ]) {
+      expect(existsSync(expected)).toBe(true);
+    }
+  });
+});

--- a/packages/saltcorn-mobile-builder/tests/webpack.test.ts
+++ b/packages/saltcorn-mobile-builder/tests/webpack.test.ts
@@ -70,7 +70,7 @@ describe("webpack build", () => {
     expect(output.indexOf(" compiled with ")).toBeGreaterThan(-1);
     for (const expected of [
       bundleDir,
-      join(bundleDir, "any-bootstrap-theme.js"),
+      join(bundleDir, "any-bootstrap-theme.bundle.js"),
       join(bundleDir, "tabulator.bundle.js"),
     ]) {
       expect(existsSync(expected)).toBe(true);

--- a/packages/saltcorn-mobile-builder/utils/common-build-utils.ts
+++ b/packages/saltcorn-mobile-builder/utils/common-build-utils.ts
@@ -15,6 +15,7 @@ import Page from "@saltcorn/data/models/page";
 import File from "@saltcorn/data/models/file";
 import type User from "@saltcorn/data/models/user";
 import { getState } from "@saltcorn/data/db/state";
+import type { PluginLayout } from "@saltcorn/types/base_types";
 
 /**
  * copy files from 'server/public' into the www folder (with a version_tag prefix)
@@ -251,8 +252,7 @@ export async function prepareSplashPage(
       }
     );
     const sbadmin2 = state.plugins["sbadmin2"];
-    // @ts-ignore TODO CH fix base_types
-    const html = sbadmin2.layout.wrap({
+    const html = (<PluginLayout>sbadmin2.layout).wrap({
       title: page.title,
       body: contents.above ? contents : { above: [contents] },
       alerts: [],

--- a/packages/saltcorn-types/base_types.ts
+++ b/packages/saltcorn-types/base_types.ts
@@ -40,6 +40,8 @@ export type FieldLike = FieldLikeWithInputType | FieldLikeWithType;
 
 export type Header = {
   script?: string;
+  css?: string;
+  headerTag?: string;
 };
 
 type MenuItem = {
@@ -90,6 +92,8 @@ export type PluginWrapArg = {
     msg: string | string[];
   }>;
   headers: Array<Header>;
+  bodyClass: string;
+  role?: number;
 };
 
 type PluginAuthwrapArg = {
@@ -113,7 +117,7 @@ type PluginAuthwrapArg = {
   };
 };
 
-export type PluginWrap = (arg0: PluginAuthwrapArg) => string;
+export type PluginWrap = (arg0: PluginWrapArg) => string;
 
 export type PluginLayout = {
   wrap: PluginWrap;
@@ -290,7 +294,7 @@ export type Plugin = {
   plugin_name?: string;
   headers: MaybeCfgFun<Array<Header>>;
   functions: MaybeCfgFun<PluginFunction | ((arg1: any) => any)>;
-  layout: MaybeCfgFun<PluginLayout>;
+  layout: MaybeCfgFun<PluginLayout> | PluginLayout;
   types: MaybeCfgFun<Array<PluginType>>;
   viewtemplates: MaybeCfgFun<Array<ViewTemplate>>;
   configuration_workflow?: ([]) => AbstractWorkflow;


### PR DESCRIPTION
- Vagrant tests with an Android emulator and appium for the ui tests
- libvirt is required as provider, and the machines need a lot of RAM.
- The appium tests are in the mobile-builder package, and the vagrant machine copies those files into its file system.
- It takes some time until the emulator is ready to install apks. So I added a long wait.
- The appium tests are rudimental, but if that works, we can write more of them.
