### PR TITLE
mobile onclicks, plugin-selector, sync ownership, wakelock, auto public login

### DIFF
--- a/packages/saltcorn-cli/src/commands/build-app.js
+++ b/packages/saltcorn-cli/src/commands/build-app.js
@@ -40,9 +40,11 @@ class BuildAppCommand extends Command {
     }
   }
 
-  async uniquePlugins() {
+  async uniquePlugins(toInclude) {
     const dynamicPlugins = (await Plugin.find()).filter(
-      (plugin) => !this.staticPlugins.includes(plugin.name)
+      (plugin) =>
+        !this.staticPlugins.includes(plugin.name) &&
+        (!toInclude || toInclude.includes(plugin.name))
     );
     const pluginsMap = new Map();
     for (const plugin of dynamicPlugins) {
@@ -82,12 +84,13 @@ class BuildAppCommand extends Command {
         platforms: flags.platforms,
         localUserTables: flags.localUserTables,
         synchedTables: flags.synchedTables,
+        includedPlugins: flags.includedPlugins,
         entryPoint: flags.entryPoint,
         entryPointType: flags.entryPointType ? flags.entryPointType : "view",
         serverURL: flags.serverURL,
         splashPage: flags.splashPage,
         allowOfflineMode: flags.allowOfflineMode,
-        plugins: await this.uniquePlugins(),
+        plugins: await this.uniquePlugins(flags.includedPlugins),
         copyTargetDir: flags.copyAppDirectory,
         user,
         buildForEmulator: flags.buildForEmulator,
@@ -143,6 +146,14 @@ BuildAppCommand.flags = {
     string: "synchedTables",
     description:
       "Table names for which the offline should be synchronized with the saltcorn server",
+    multiple: true,
+  }),
+  includedPlugins: flags.string({
+    name: "included plugins",
+    string: "includedPlugins",
+    description:
+      "Names of plugins that should be bundled into the app." +
+      "If empty, all installed modules are used.",
     multiple: true,
   }),
   useDocker: flags.boolean({

--- a/packages/saltcorn-cli/src/commands/build-app.js
+++ b/packages/saltcorn-cli/src/commands/build-app.js
@@ -89,6 +89,7 @@ class BuildAppCommand extends Command {
         entryPointType: flags.entryPointType ? flags.entryPointType : "view",
         serverURL: flags.serverURL,
         splashPage: flags.splashPage,
+        autoPublicLogin: flags.autoPublicLogin,
         allowOfflineMode: flags.allowOfflineMode,
         plugins: await this.uniquePlugins(flags.includedPlugins),
         copyTargetDir: flags.copyAppDirectory,
@@ -203,6 +204,11 @@ BuildAppCommand.flags = {
     string: "splashPage",
     description:
       "Name of a page that should be shown while the app is loading.",
+  }),
+  autoPublicLogin: flags.boolean({
+    name: "auto public login",
+    string: "autoPublicLogin",
+    description: "Show public entry points before the login as a public user.",
   }),
   allowOfflineMode: flags.boolean({
     name: "Allow offline mode",

--- a/packages/saltcorn-data/models/view.ts
+++ b/packages/saltcorn-data/models/view.ts
@@ -411,7 +411,8 @@ class View implements AbstractView {
     extraArgs: RunExtra,
     remote: boolean = !isNode()
   ): Promise<any> {
-    this.check_viewtemplate();
+    if (isWeb(extraArgs.req)) this.check_viewtemplate();
+    else if (!this.viewtemplateObj) return "";
     const table_id = this.exttable_name || this.table_id;
     const state = require("../db/state").getState();
     try {
@@ -504,7 +505,8 @@ class View implements AbstractView {
     remote: boolean = false
   ): Promise<string | { goto?: string }> {
     const view = this;
-    this.check_viewtemplate();
+    if (isWeb(req)) this.check_viewtemplate();
+    else if (!this.viewtemplateObj) return "";
     if (view.default_render_page && (!req.xhr || req.headers.pjaxpageload)) {
       const Page = require("../models/page");
       const db_page = await Page.findOne({ name: view.default_render_page });
@@ -539,7 +541,8 @@ class View implements AbstractView {
     extraArgs: RunExtra,
     remote?: boolean
   ): Promise<string[] | Array<{ html: string; row: any }>> {
-    this.check_viewtemplate();
+    if (isWeb(extraArgs.req)) this.check_viewtemplate();
+    else if (!this.viewtemplateObj) return [];
     require("../db/state")
       .getState()
       .log(5, `runMany view ${this.name} with state ${JSON.stringify(query)}`);
@@ -616,7 +619,8 @@ class View implements AbstractView {
     ) {
       remote = false;
     }
-    this.check_viewtemplate();
+    if (isWeb(extraArgs.req)) this.check_viewtemplate();
+    else if (!this.viewtemplateObj) return;
     getState().log(
       5,
       `runPost view ${this.name} with state ${JSON.stringify(query)}`
@@ -652,12 +656,12 @@ class View implements AbstractView {
     extraArgs: RunExtra,
     remote: boolean = false
   ): Promise<any> {
-    this.check_viewtemplate();
+    if (isWeb(extraArgs.req)) this.check_viewtemplate();
+    else if (!this.viewtemplateObj) return res.json({ excluded: true });
     if (!this.viewtemplateObj!.routes)
       throw new InvalidConfiguration(
         `Unable to call runRoute of view '${this.name}', ${this.viewtemplate} is missing 'routes'.`
       );
-    this.check_viewtemplate();
     require("../db/state")
       .getState()
       .log(
@@ -683,7 +687,8 @@ class View implements AbstractView {
    */
   combine_state_and_default_state(req_query: any): any {
     var state = { ...req_query };
-    this.check_viewtemplate();
+    if (isNode()) this.check_viewtemplate();
+    else if (!this.viewtemplateObj) return state;
     const defstate = this.viewtemplateObj!.default_state_form
       ? this.viewtemplateObj!.default_state_form(this.configuration)
       : {};

--- a/packages/saltcorn-data/utils.ts
+++ b/packages/saltcorn-data/utils.ts
@@ -182,7 +182,7 @@ const isNode = (): boolean => {
  * @param req express request
  */
 const isWeb = (req: any): boolean => {
-  return isNode() && !req.smr;
+  return isNode() && !req?.smr;
 };
 
 /**

--- a/packages/saltcorn-markup/layout.ts
+++ b/packages/saltcorn-markup/layout.ts
@@ -357,7 +357,8 @@ const render = ({
         )
       );
     }
-    if (segment.type === "card")
+    if (segment.type === "card") {
+      const isWeb = typeof window === "undefined" && !req?.smr;
       return wrap(
         segment,
         isTop,
@@ -371,7 +372,11 @@ const render = ({
               segment.class,
               segment.url && "with-link",
             ],
-            onclick: segment.url ? `location.href='${segment.url}'` : false,
+            onclick: segment.url
+              ? isWeb
+                ? `location.href='${segment.url}'`
+                : `execLink('${segment.url}')`
+              : false,
             style: segment.style,
           },
           segment.title &&
@@ -450,6 +455,7 @@ const render = ({
           segment.footer && div({ class: "card-footer" }, go(segment.footer))
         )
       );
+    }
     if (segment.type === "tabs") {
       return wrap(
         segment,
@@ -587,7 +593,11 @@ const render = ({
               hoverColor && `hover-${hoverColor}`,
               fullPageWidth && "full-page-width",
             ],
-            onclick: segment.url ? `location.href='${segment.url}'` : false,
+            onclick: segment.url
+              ? isWeb
+                ? `location.href='${segment.url}'`
+                : `execLink('${segment.url}')`
+              : false,
 
             style: `${flexStyles}${ppCustomCSS(customCSS || "")}${sizeProp(
               "minHeight",

--- a/packages/saltcorn-mobile-app/config.xml
+++ b/packages/saltcorn-mobile-app/config.xml
@@ -7,6 +7,9 @@
     <edit-config file="app/src/main/AndroidManifest.xml" target="/manifest/application" mode="merge">
       <application android:usesCleartextTraffic="true"/>
     </edit-config>
+    <config-file parent="/manifest" target="AndroidManifest.xml">
+      <uses-permission android:name="android.permission.WAKE_LOCK" />
+    </config-file>
     <preference name="Scheme" value="http"/>
     <preference name="MixedContentMode" value="2"/>
   </platform>

--- a/packages/saltcorn-mobile-app/www/index.html
+++ b/packages/saltcorn-mobile-app/www/index.html
@@ -193,6 +193,22 @@
         }
       };
 
+      const showErrorPage = async (error) => {
+        const state = saltcorn.data.state.getState();
+        state.mobileConfig.inErrorState = true;
+        const page = await router.resolve({
+          pathname: "get/error_page",
+          fullWrap: true,
+          alerts: [
+            {
+              type: "error",
+              msg: error.message ? error.message : "An error occured.",
+            },
+          ],
+        });
+        await replaceIframe(page.content);
+      };
+
       // the app comes back from background
       const onResume = async () => {
         if (typeof saltcorn === "undefined") return;
@@ -205,25 +221,29 @@
             !mobileConfig.isOfflineMode &&
             mobileConfig.jwt
           ) {
-            await offlineHelper.startOfflineMode();
-            clearHistory();
-            if (mobileConfig.user_id) await gotoEntryView();
-            else {
-              const decodedJwt = jwt_decode(mobileConfig.jwt);
-              mobileConfig.role_id = decodedJwt.user.role_id
-                ? decodedJwt.user.role_id
-                : 100;
-              mobileConfig.user_id = decodedJwt.user.id;
-              mobileConfig.user_name = decodedJwt.user.email;
-              mobileConfig.language = decodedJwt.user.language;
-              mobileConfig.isPublicUser = false;
+            try {
+              await offlineHelper.startOfflineMode();
+              clearHistory();
+              if (mobileConfig.user_id) await gotoEntryView();
+              else {
+                const decodedJwt = jwt_decode(mobileConfig.jwt);
+                mobileConfig.role_id = decodedJwt.user.role_id
+                  ? decodedJwt.user.role_id
+                  : 100;
+                mobileConfig.user_id = decodedJwt.user.id;
+                mobileConfig.user_name = decodedJwt.user.email;
+                mobileConfig.language = decodedJwt.user.language;
+                mobileConfig.isPublicUser = false;
+              }
+              addRoute({ route: entryPoint, query: undefined });
+              const page = await router.resolve({
+                pathname: mobileConfig.entry_point,
+                fullWrap: true,
+                alerts: [],
+              });
+            } catch (error) {
+              await showErrorPage(error);
             }
-            addRoute({ route: entryPoint, query: undefined });
-            const page = await router.resolve({
-              pathname: mobileConfig.entry_point,
-              fullWrap: true,
-              alerts: [],
-            });
           }
         }
       };
@@ -348,13 +368,20 @@
                   throw new Error(
                     `The offline mode is not available, '${offlineUser}' has not yet uploaded offline data.`
                   );
-                else {
-                  await offlineHelper.startOfflineMode();
-                  alerts.push({
-                    type: "info",
-                    msg: offlineHelper.getOfflineMsg(),
-                  });
-                }
+                else
+                  try {
+                    await offlineHelper.startOfflineMode();
+                    alerts.push({
+                      type: "info",
+                      msg: offlineHelper.getOfflineMsg(),
+                    });
+                  } catch (error) {
+                    throw new Error(
+                      `Neither an internet connection nor the offline mode are available: ${
+                        error.message ? error.message : "Unknown error"
+                      }`
+                    );
+                  }
               } else if (offlineUser) {
                 if (offlineUser === mobileConfig.user_name) {
                   await offlineHelper.sync();
@@ -397,24 +424,16 @@
             });
             await replaceIframe(page.content);
           } else if (await isPublicEntryPoint(entryPoint)) {
+            if (networkDisabled)
+              throw new Error(
+                "No internet connection or previous login is available. " +
+                  "Please go online and reload, the public login is not yet supported."
+              );
             await publicLogin(entryPoint);
           } else await showLogin(alerts);
         } catch (error) {
           if (error.httpCode === 401) await showLogin([]);
-          else {
-            state.mobileConfig.inErrorState = true;
-            const page = await router.resolve({
-              pathname: "get/error_page",
-              fullWrap: true,
-              alerts: [
-                {
-                  type: "error",
-                  msg: error.message ? error.message : "An error occured.",
-                },
-              ],
-            });
-            await replaceIframe(page.content);
-          }
+          else await showErrorPage(error);
         }
       };
 

--- a/packages/saltcorn-mobile-app/www/index.html
+++ b/packages/saltcorn-mobile-app/www/index.html
@@ -423,7 +423,10 @@
               alerts,
             });
             await replaceIframe(page.content);
-          } else if (await isPublicEntryPoint(entryPoint)) {
+          } else if (
+            (await isPublicEntryPoint(entryPoint)) &&
+            state.mobileConfig.autoPublicLogin
+          ) {
             if (networkDisabled)
               throw new Error(
                 "No internet connection or previous login is available. " +

--- a/packages/saltcorn-mobile-app/www/js/utils/iframe_view_utils.js
+++ b/packages/saltcorn-mobile-app/www/js/utils/iframe_view_utils.js
@@ -250,12 +250,8 @@ async function publicLogin(entryPoint) {
       throw new Error("The login failed.");
     }
   } catch (error) {
-    parent.showAlerts([
-      {
-        type: "error",
-        msg: error.message ? error.message : "An error occured.",
-      },
-    ]);
+    console.log(error);
+    throw error;
   } finally {
     removeLoadSpinner();
   }

--- a/packages/saltcorn-mobile-app/www/js/utils/offline_mode_helper.js
+++ b/packages/saltcorn-mobile-app/www/js/utils/offline_mode_helper.js
@@ -1,4 +1,4 @@
-/*global $, apiCall, saltcorn, navigator, clearAlerts*/
+/*global window, $, apiCall, saltcorn, navigator, clearAlerts*/
 
 var offlineHelper = (() => {
   const setUploadStarted = async (started, time) => {

--- a/packages/saltcorn-mobile-app/www/js/utils/offline_mode_helper.js
+++ b/packages/saltcorn-mobile-app/www/js/utils/offline_mode_helper.js
@@ -423,7 +423,10 @@ var offlineHelper = (() => {
         );
         const syncTimestamp = await getSyncTimestamp();
         await setUploadStarted(true, syncTimestamp);
+        let lock = null;
         try {
+          if (window.navigator.wakeLock?.request)
+            lock = await window.navigator.wakeLock.request();
           await saltcorn.data.db.query("PRAGMA foreign_keys = OFF;");
           await saltcorn.data.db.query("BEGIN");
           if (cleanSync) await offlineHelper.clearLocalData(true);
@@ -440,8 +443,10 @@ var offlineHelper = (() => {
           await saltcorn.data.db.query("PRAGMA foreign_keys = ON;");
           console.log(error);
           throw error;
+        } finally {
+          if (syncDir) await cleanSyncDir(syncDir);
+          if (lock) await lock.release();
         }
-        if (syncDir) await cleanSyncDir(syncDir);
       }
     },
 
@@ -453,27 +458,37 @@ var offlineHelper = (() => {
         await offlineHelper.setOfflineSession({
           offlineUser: mobileConfig.user_name,
         });
-        mobileConfig.isOfflineMode = true;
-      } else if (oldSession.offlineUser !== mobileConfig.user_name) {
-        if (oldSession.hasOfflineData) {
+      } else if (
+        oldSession.offlineUser &&
+        oldSession.offlineUser !== mobileConfig.user_name
+      ) {
+        if (oldSession.hasOfflineData)
           throw new Error(
             `The offline mode is not available, '${oldSession.offlineUser}' has not yet uploaded offline data.`
           );
-        } else {
-          await offlineHelper.setOfflineSession({
-            offlineUser: mobileConfig.user_name,
-          });
-          mobileConfig.isOfflineMode = true;
-        }
+      } else if (oldSession.uploadStarted) {
+        throw new Error(
+          `A previous Synchronization did not finish. Please ${
+            mobileConfig.networkState === "none" ? "go online and " : ""
+          } try it again.`
+        );
       } else {
-        mobileConfig.isOfflineMode = true;
+        await offlineHelper.setOfflineSession({
+          offlineUser: mobileConfig.user_name,
+        });
       }
+      mobileConfig.isOfflineMode = true;
     },
     endOfflineMode: async (endSession = false) => {
       const state = saltcorn.data.state.getState();
       const mobileConfig = state.mobileConfig;
       mobileConfig.isOfflineMode = false;
-      if (!(await offlineHelper.hasOfflineRows()) || endSession)
+      const oldSession = await offlineHelper.getLastOfflineSession();
+      if (
+        (!oldSession?.uploadStarted &&
+          !(await offlineHelper.hasOfflineRows())) ||
+        endSession
+      )
         await state.setConfig("last_offline_session", null);
     },
     getLastOfflineSession: async () => {
@@ -493,6 +508,7 @@ var offlineHelper = (() => {
     },
     clearLocalData: async (inTransaction) => {
       try {
+        await saltcorn.data.db.query("PRAGMA foreign_keys = OFF;");
         if (!inTransaction) await saltcorn.data.db.query("BEGIN");
         const { synchedTables } = saltcorn.data.state.getState().mobileConfig;
         for (const tblName of synchedTables) {
@@ -501,8 +517,12 @@ var offlineHelper = (() => {
           await saltcorn.data.db.deleteWhere(`${table.name}_sync_info`, {});
         }
         if (!inTransaction) await saltcorn.data.db.query("COMMIT");
+        await saltcorn.data.db.query("PRAGMA foreign_keys = ON;");
       } catch (error) {
-        if (!inTransaction) await saltcorn.data.db.query("ROLLBACK");
+        if (!inTransaction) {
+          await saltcorn.data.db.query("ROLLBACK");
+          await saltcorn.data.db.query("PRAGMA foreign_keys = ON;");
+        }
         throw error;
       }
     },

--- a/packages/saltcorn-mobile-builder/mobile-builder.ts
+++ b/packages/saltcorn-mobile-builder/mobile-builder.ts
@@ -52,6 +52,7 @@ export class MobileBuilder {
   entryPointType: EntryPointType;
   serverURL: string;
   splashPage?: string;
+  autoPublicLogin: string;
   allowOfflineMode: string;
   pluginManager: any;
   plugins: Plugin[];
@@ -81,6 +82,7 @@ export class MobileBuilder {
     entryPointType: EntryPointType;
     serverURL: string;
     splashPage?: string;
+    autoPublicLogin: string;
     allowOfflineMode: string;
     plugins: Plugin[];
     copyTargetDir?: string;
@@ -103,6 +105,7 @@ export class MobileBuilder {
     this.entryPointType = cfg.entryPointType;
     this.serverURL = cfg.serverURL;
     this.splashPage = cfg.splashPage;
+    this.autoPublicLogin = cfg.allowOfflineMode;
     this.allowOfflineMode = cfg.allowOfflineMode;
     this.pluginManager = new PluginManager({
       pluginsPath: join(this.buildDir, "plugin_packages", "node_modules"),
@@ -135,6 +138,7 @@ export class MobileBuilder {
       localUserTables: this.localUserTables,
       synchedTables: this.synchedTables,
       tenantAppName: this.tenantAppName,
+      autoPublicLogin: this.autoPublicLogin,
       allowOfflineMode: this.allowOfflineMode,
     });
     let resultCode = await bundlePackagesAndPlugins(

--- a/packages/saltcorn-mobile-builder/mobile-builder.ts
+++ b/packages/saltcorn-mobile-builder/mobile-builder.ts
@@ -47,6 +47,7 @@ export class MobileBuilder {
   platforms: string[];
   localUserTables: string[];
   synchedTables: string[];
+  includedPlugins: string[];
   entryPoint: string;
   entryPointType: EntryPointType;
   serverURL: string;
@@ -75,6 +76,7 @@ export class MobileBuilder {
     platforms: string[];
     localUserTables?: string[];
     synchedTables?: string[];
+    includedPlugins?: string[];
     entryPoint: string;
     entryPointType: EntryPointType;
     serverURL: string;
@@ -96,6 +98,7 @@ export class MobileBuilder {
     this.platforms = cfg.platforms;
     this.localUserTables = cfg.localUserTables ? cfg.localUserTables : [];
     this.synchedTables = cfg.synchedTables ? cfg.synchedTables : [];
+    this.includedPlugins = cfg.includedPlugins ? cfg.includedPlugins : [];
     this.entryPoint = cfg.entryPoint;
     this.entryPointType = cfg.entryPointType;
     this.serverURL = cfg.serverURL;
@@ -143,7 +146,7 @@ export class MobileBuilder {
     await loadAllPlugins();
     await copyPublicDirs(this.buildDir);
     await installNpmPackages(this.buildDir, this.pluginManager);
-    await buildTablesFile(this.buildDir);
+    await buildTablesFile(this.buildDir, this.includedPlugins);
     if (this.splashPage)
       await prepareSplashPage(
         this.buildDir,

--- a/packages/saltcorn-mobile-builder/utils/common-build-utils.ts
+++ b/packages/saltcorn-mobile-builder/utils/common-build-utils.ts
@@ -136,6 +136,7 @@ export function writeCfgFile({
   localUserTables,
   synchedTables,
   tenantAppName,
+  autoPublicLogin,
   allowOfflineMode,
 }: any) {
   const wwwDir = join(buildDir, "www");
@@ -147,6 +148,7 @@ export function writeCfgFile({
       : serverPath.substring(0, serverPath.length - 1),
     localUserTables,
     synchedTables,
+    autoPublicLogin,
     allowOfflineMode,
   };
   if (tenantAppName) cfg.tenantAppName = tenantAppName;

--- a/packages/saltcorn-types/base_types.ts
+++ b/packages/saltcorn-types/base_types.ts
@@ -339,6 +339,7 @@ export type MobileConfig = {
   // server_path <=> base_url
   localTableIds: number[];
   synchedTables: string[];
+  autoPublicLogin: boolean;
   allowOfflineMode?: boolean;
   isOfflineMode?: boolean;
   networkState?:

--- a/packages/server/locales/en.json
+++ b/packages/server/locales/en.json
@@ -1242,5 +1242,8 @@
 	"unsynched": "unsynched",
 	"synched": "synched",
 	"Sync information": "Sync information",
-	"Sync information tracks the last modification or deletion timestamp so that the table data can be synchronized with the mobile app": "Sync information tracks the last modification or deletion timestamp so that the table data can be synchronized with the mobile app"
+	"Sync information tracks the last modification or deletion timestamp so that the table data can be synchronized with the mobile app": "Sync information tracks the last modification or deletion timestamp so that the table data can be synchronized with the mobile app",
+	"Included Plugins": "Included Plugins",
+	"exclude": "exclude",
+	"include": "include"
 }

--- a/packages/server/locales/en.json
+++ b/packages/server/locales/en.json
@@ -1245,5 +1245,6 @@
 	"Sync information tracks the last modification or deletion timestamp so that the table data can be synchronized with the mobile app": "Sync information tracks the last modification or deletion timestamp so that the table data can be synchronized with the mobile app",
 	"Included Plugins": "Included Plugins",
 	"exclude": "exclude",
-	"include": "include"
+	"include": "include",
+	"Auto public login": "Auto public login"
 }

--- a/packages/server/public/saltcorn.js
+++ b/packages/server/public/saltcorn.js
@@ -678,6 +678,10 @@ function build_mobile_app(button) {
   params.synchedTables = Array.from($("#synched-tbls-select-id")[0].options)
     .filter((option) => !option.hidden)
     .map((option) => option.value);
+  const pluginsSelect = $("#included-plugins-select-id")[0];
+  params.includedPlugins = Array.from(pluginsSelect.options)
+    .filter((option) => !option.hidden)
+    .map((option) => option.value);
   ajax_post("/admin/build-mobile-app", {
     data: params,
     success: (data) => {
@@ -714,6 +718,32 @@ function move_to_unsynched() {
     const jUnsOpt = $(`[id='${selected}_unsynched_opt']`);
     jUnsOpt.removeAttr("hidden");
     jUnsOpt.removeAttr("selected");
+  }
+}
+
+function move_plugin_to_included() {
+  const opts = $("#excluded-plugins-select-id");
+  $("#included-plugins-select-id").removeAttr("selected");
+  for (const selected of opts.val()) {
+    const jExclOpt = $(`[id='${selected}_excluded_opt']`);
+    jExclOpt.attr("hidden", "true");
+    jExclOpt.removeAttr("selected");
+    const jInclOpt = $(`[id='${selected}_included_opt']`);
+    jInclOpt.removeAttr("hidden");
+    jInclOpt.removeAttr("selected");
+  }
+}
+
+function move_plugin_to_excluded() {
+  const opts = $("#included-plugins-select-id");
+  $("#excluded-plugins-select-id").removeAttr("selected");
+  for (const selected of opts.val()) {
+    const jInclOpt = $(`[id='${selected}_included_opt']`);
+    jInclOpt.attr("hidden", "true");
+    jInclOpt.removeAttr("selected");
+    const jExclOpt = $(`[id='${selected}_excluded_opt']`);
+    jExclOpt.removeAttr("hidden");
+    jExclOpt.removeAttr("selected");
   }
 }
 

--- a/packages/server/routes/admin.js
+++ b/packages/server/routes/admin.js
@@ -1753,7 +1753,29 @@ router.get(
                       )
                     )
                   ),
-
+                  // auto public login box
+                  div(
+                    { class: "row pb-2" },
+                    div(
+                      { class: "col-sm-4" },
+                      input({
+                        type: "checkbox",
+                        id: "autoPublLoginId",
+                        class: "form-check-input me-2",
+                        name: "autoPublicLogin",
+                        value: "autoPublicLogin",
+                        checked: false,
+                      }),
+                      label(
+                        {
+                          for: "autoPublLoginId",
+                          class: "form-label",
+                        },
+                        req.__("Auto public login")
+                      )
+                    )
+                  ),
+                  // allow offline mode box
                   div(
                     { class: "row pb-2" },
                     div(
@@ -2064,6 +2086,7 @@ router.post(
       appIcon,
       serverURL,
       splashPage,
+      autoPublicLogin,
       allowOfflineMode,
       synchedTables,
       includedPlugins,
@@ -2118,6 +2141,7 @@ router.post(
     if (serverURL) spawnParams.push("-s", serverURL);
     if (splashPage) spawnParams.push("--splashPage", splashPage);
     if (allowOfflineMode) spawnParams.push("--allowOfflineMode");
+    if (autoPublicLogin) spawnParams.push("--autoPublicLogin");
     if (synchedTables?.length > 0)
       spawnParams.push("--synchedTables", ...synchedTables.map((tbl) => tbl));
     if (includedPlugins?.length > 0)


### PR DESCRIPTION
- onclick handler for cards and container
- plugin selector for modules that should be included into the build
- check ownership field of the synched rows
- add a wackelock while synching
- shutting down the app or phone while synching blocks the offline mode until the next sync
- only do a automatic public login when the new 'auto public login' checkbox is clicked, otherwise it could result in too many sync calls