### PR TITLE
Allow to use external tables in dynamic menu entries

### DIFF
--- a/packages/server/routes/menu.js
+++ b/packages/server/routes/menu.js
@@ -44,7 +44,7 @@ const menuForm = async (req) => {
   const views = await View.find({}, { orderBy: "name", nocase: true });
   const pages = await Page.find({}, { orderBy: "name", nocase: true });
   const roles = await User.get_roles();
-  const tables = await Table.find({});
+  const tables = await Table.find_with_external({});
   const dynTableOptions = tables.map((t) => t.name);
   const dynOrderFieldOptions = {},
     dynSectionFieldOptions = {};


### PR DESCRIPTION
Especially useful with [config-tables](https://github.com/pyhedgehog/saltcorn-config-tables) plugin. 😃 