### PR TITLE
mobile links, restore entryPointType, improvements

### DIFF
--- a/packages/saltcorn-cli/src/commands/build-app.js
+++ b/packages/saltcorn-cli/src/commands/build-app.js
@@ -154,7 +154,7 @@ BuildAppCommand.flags = {
     string: "includedPlugins",
     description:
       "Names of plugins that should be bundled into the app." +
-      "If empty, all installed modules are used.",
+      "If empty, no modules are used.",
     multiple: true,
   }),
   useDocker: flags.boolean({

--- a/packages/saltcorn-cli/src/commands/build-app.js
+++ b/packages/saltcorn-cli/src/commands/build-app.js
@@ -44,7 +44,7 @@ class BuildAppCommand extends Command {
     const dynamicPlugins = (await Plugin.find()).filter(
       (plugin) =>
         !this.staticPlugins.includes(plugin.name) &&
-        (!toInclude || toInclude.includes(plugin.name))
+        toInclude?.includes(plugin.name)
     );
     const pluginsMap = new Map();
     for (const plugin of dynamicPlugins) {

--- a/packages/saltcorn-data/tests/exact_views.test.ts
+++ b/packages/saltcorn-data/tests/exact_views.test.ts
@@ -253,7 +253,7 @@ describe("Show view", () => {
       ],
       response: !remoteQueries
         ? `<div class="row w-100"><div class="col-6"><div class="card mt-4 shadow"><div class="card-body"><a href="javascript:ajax_modal('/view/authorshow?id=1')">foo it</a></div></div></div><div class="col-6"><div class="text-start" style="min-height: 100px;border: 1px solid black;  background-color: #a9a7a7;  "><a href="https://countto.com/967">Herman Melville</a></div></div></div>`
-        : `<div class="row w-100"><div class="col-6"><div class="card mt-4 shadow"><div class="card-body"><a href="javascript:mobile_modal('/view/authorshow?id=1')">foo it</a></div></div></div><div class="col-6"><div class="text-start" style="min-height: 100px;border: 1px solid black;  background-color: #a9a7a7;  "><a href="javascript:execLink('https://countto.com/967')">Herman Melville</a></div></div></div>`,
+        : `<div class="row w-100"><div class="col-6"><div class="card mt-4 shadow"><div class="card-body"><a href="javascript:mobile_modal('/view/authorshow?id=1')">foo it</a></div></div></div><div class="col-6"><div class="text-start" style="min-height: 100px;border: 1px solid black;  background-color: #a9a7a7;  "><a href="javascript:execLink('https://countto.com/967', 'URL')">Herman Melville</a></div></div></div>`,
     });
     await test_show({
       layout: {

--- a/packages/saltcorn-markup/layout.ts
+++ b/packages/saltcorn-markup/layout.ts
@@ -346,7 +346,6 @@ const render = ({
               segment.link_textcol || "#000000"
             }`
           : null;
-      const mobile = typeof window !== "undefined";
       return wrap(
         segment,
         isTop,
@@ -354,14 +353,16 @@ const render = ({
         a(
           {
             href: segment.in_modal
-              ? !mobile
+              ? isWeb
                 ? `javascript:ajax_modal('${segment.url}');`
                 : `javascript:mobile_modal('${segment.url}');`
-              : !mobile
+              : isWeb
               ? segment.url
-              : `javascript:execLink('${segment.url}', '${segment.link_src}' )`,
+              : `javascript:execLink('${segment.url}', '${
+                  segment.link_src || "URL"
+                }')`,
             class: [segment.link_style || "", segment.link_size || ""],
-            target: segment.target_blank ? "_blank" : false,
+            target: isWeb && segment.target_blank ? "_blank" : false,
             rel: segment.nofollow ? "nofollow" : false,
             style,
           },

--- a/packages/saltcorn-markup/layout.ts
+++ b/packages/saltcorn-markup/layout.ts
@@ -359,7 +359,7 @@ const render = ({
                 : `javascript:mobile_modal('${segment.url}');`
               : !mobile
               ? segment.url
-              : `javascript:execLink('${segment.url}')`,
+              : `javascript:execLink('${segment.url}', '${segment.link_src}' )`,
             class: [segment.link_style || "", segment.link_size || ""],
             target: segment.target_blank ? "_blank" : false,
             rel: segment.nofollow ? "nofollow" : false,

--- a/packages/saltcorn-mobile-app/www/js/utils/iframe_view_utils.js
+++ b/packages/saltcorn-mobile-app/www/js/utils/iframe_view_utils.js
@@ -16,17 +16,22 @@ function combineFormAndQuery(form, query) {
 }
 
 /**
- *
- * @param {*} url
+ * Pass View or Page source into the app internal router,
+ * links with an URL source are opened in the system browser.
+ * @param {string} url
+ * @param {string} linkSrc - URL, View or Page
  */
-async function execLink(url) {
-  try {
-    showLoadSpinner();
-    const { path, query } = parent.splitPathQuery(url);
-    await parent.handleRoute(`get${path}`, query);
-  } finally {
-    removeLoadSpinner();
-  }
+async function execLink(url, linkSrc) {
+  if (linkSrc === "URL") {
+    parent.cordova.InAppBrowser.open(url, "_system");
+  } else
+    try {
+      showLoadSpinner();
+      const { path, query } = parent.splitPathQuery(url);
+      await parent.handleRoute(`get${path}`, query);
+    } finally {
+      removeLoadSpinner();
+    }
 }
 
 async function execNavbarLink(url) {

--- a/packages/saltcorn-mobile-app/www/js/utils/iframe_view_utils.js
+++ b/packages/saltcorn-mobile-app/www/js/utils/iframe_view_utils.js
@@ -253,7 +253,13 @@ async function publicLogin(entryPoint) {
         alerts: [
           {
             type: "success",
-            msg: parent.i18next.t("Welcome to Saltcorn!"),
+            msg: parent.i18next.t("Welcome to %s!", {
+              postProcess: "sprintf",
+              sprintf: [
+                parent.saltcorn.data.state.getState().getConfig("site_name") ||
+                  "Saltcorn",
+              ],
+            }),
           },
         ],
       });
@@ -265,6 +271,12 @@ async function publicLogin(entryPoint) {
     }
   } catch (error) {
     console.log(error);
+    parent.showAlerts([
+      {
+        type: "error",
+        msg: error.message ? error.message : "An error occured.",
+      },
+    ]);
     throw error;
   } finally {
     removeLoadSpinner();

--- a/packages/server/auth/routes.js
+++ b/packages/server/auth/routes.js
@@ -228,7 +228,7 @@ const loginWithJwt = async (email, password, saltcornApp, res, req) => {
   const loginFn = async () => {
     const publicUserLink = getState().getConfig("public_user_link");
     const jwt_secret = db.connectObj.jwt_secret;
-    if (email && password) {
+    if (email !== undefined && password !== undefined) {
       // with credentials
       const user = await User.findOne({ email });
       if (user && user.checkPassword(password)) {

--- a/packages/server/routes/admin.js
+++ b/packages/server/routes/admin.js
@@ -1545,7 +1545,7 @@ router.get(
                 input({
                   type: "hidden",
                   name: "entryPointType",
-                  value: "view",
+                  value: builderSettings.entryPointType || "view",
                   id: "entryPointTypeID",
                 }),
                 div(
@@ -1578,7 +1578,8 @@ router.get(
                           div(
                             {
                               class: `nav-link ${
-                                !builderSettings.entryPointType || builderSettings.entryPointType === "view"
+                                !builderSettings.entryPointType ||
+                                builderSettings.entryPointType === "view"
                                   ? "active"
                                   : ""
                               }`,
@@ -1613,7 +1614,8 @@ router.get(
                               ? "d-none"
                               : ""
                           }`,
-                          ...(!builderSettings.entryPointType || builderSettings.entryPointType === "view"
+                          ...(!builderSettings.entryPointType ||
+                          builderSettings.entryPointType === "view"
                             ? { name: "entryPoint" }
                             : {}),
                           id: "viewInputID",
@@ -1636,7 +1638,8 @@ router.get(
                       select(
                         {
                           class: `form-select ${
-                            !builderSettings.entryPointType || builderSettings.entryPointType === "view"
+                            !builderSettings.entryPointType ||
+                            builderSettings.entryPointType === "view"
                               ? "d-none"
                               : ""
                           }`,


### PR DESCRIPTION
- open links with an URL source in the system browser on mobile
- restore the entryPointType in the builder menu as well
- use site name in public welcome
- try empty strings in login and let it fail