### PR TITLE
Make `saltcorn` command available in path in Dockerfile.dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,6 +10,6 @@ ENV SALTCORN_DISABLE_UPGRADE "true"
 RUN npm install --legacy-peer-deps
 RUN npm run tsc
 
-ENV PATH "$PATH:/opt/saltcorn/packages/saltcorn-cli/bin/saltcorn"
+ENV PATH "$PATH:/opt/saltcorn/packages/saltcorn-cli/bin"
 
 ENTRYPOINT ["/opt/saltcorn/packages/saltcorn-cli/bin/saltcorn"]


### PR DESCRIPTION
I'm using this patch (as a sed command in gitlab build job) for long time.