### PR TITLE
stream-interface to write into the view of a table field

### DIFF
--- a/packages/saltcorn-data/base-plugin/viewtemplates/edit.js
+++ b/packages/saltcorn-data/base-plugin/viewtemplates/edit.js
@@ -1373,6 +1373,35 @@ const authorise_post = async (
   return await authorizePostQuery(body, table_id);
 };
 
+const openDataStream = async (
+  tableId,
+  viewName,
+  fieldName,
+  fieldView,
+  user,
+  configuration,
+  targetOpts
+) => {
+  const table = Table.findOne({ id: tableId });
+  const field = table.getField(fieldName);
+  if (!field) throw new InvalidConfiguration(`Field ${fieldName} not found`);
+  if (field.type === "File") {
+    const cfgCol = configuration.columns.find(
+      (col) => col.fieldview === fieldView && col.field_name === fieldName
+    );
+    const fileView = getState().fileviews[fieldView];
+    if (!fileView)
+      throw new InvalidConfiguration(`File view ${fieldView} not found`);
+    return await fileView.openDataStream(
+      tableId,
+      fieldName,
+      user,
+      cfgCol.configuration,
+      targetOpts
+    );
+  }
+};
+
 /**
  * @param {number} table_id
  * @param {*} viewname
@@ -1589,7 +1618,7 @@ const prepare = async (
 
   const file_fields = form.fields.filter((f) => f.type === "File");
   for (const field of file_fields) {
-    if (!field.fieldviewObj?.isEdit) continue;
+    if (!field.fieldviewObj?.isEdit || field.fieldviewObj?.isStream) continue;
     if (field.fieldviewObj?.setsFileId) {
       //do nothing
     } else if (field.fieldviewObj?.setsDataURL) {
@@ -1804,6 +1833,7 @@ module.exports = {
   run,
   runMany,
   runPost,
+  openDataStream,
   get_state_fields,
   initial_config,
   /** @type {boolean} */

--- a/packages/saltcorn-data/models/file.ts
+++ b/packages/saltcorn-data/models/file.ts
@@ -166,6 +166,12 @@ class File {
     return s[0] === "/" ? s.substring(1) : s;
   }
 
+  get absolutePath(): string {
+    const tenant = db.getTenantSchema();
+    const safeDir = File.normalise(this.location);
+    return path.join(db.connectObj.file_store, tenant, safeDir);
+  }
+
   /**
    * get all directories in the root folder (tenant root dir for multi-tenant)
    * @param ignoreCache if a cache exists, ignore it

--- a/packages/saltcorn-data/models/view.ts
+++ b/packages/saltcorn-data/models/view.ts
@@ -730,6 +730,27 @@ class View implements AbstractView {
       res.json({ success: "ok" });
   }
 
+  async openDataStream(
+    fieldName: string,
+    fieldView: string,
+    user: any,
+    targetOpts: any
+  ) {
+    if (!this.viewtemplateObj?.openDataStream)
+      throw new InvalidConfiguration(
+        `Unable to call openDataStream, ${this.viewtemplate} is missing 'openDataStream'.`
+      );
+    return await this.viewtemplateObj.openDataStream(
+      this.table_id,
+      this.name,
+      fieldName,
+      fieldView,
+      user,
+      this.configuration,
+      targetOpts
+    );
+  }
+
   /**
    * @param {object} req_query
    * @returns {object}

--- a/packages/saltcorn-data/models/view.ts
+++ b/packages/saltcorn-data/models/view.ts
@@ -731,6 +731,7 @@ class View implements AbstractView {
   }
 
   async openDataStream(
+    id: number | undefined,
     fieldName: string,
     fieldView: string,
     user: any,
@@ -743,6 +744,7 @@ class View implements AbstractView {
     return await this.viewtemplateObj.openDataStream(
       this.table_id,
       this.name,
+      id,
       fieldName,
       fieldView,
       user,

--- a/packages/saltcorn-types/base_types.ts
+++ b/packages/saltcorn-types/base_types.ts
@@ -298,6 +298,7 @@ export type ViewTemplate = {
   openDataStream?: (
     table_id: number | undefined,
     viewName: string,
+    id: number | undefined,
     fieldName: string,
     fieldView: string,
     user: any,

--- a/packages/saltcorn-types/base_types.ts
+++ b/packages/saltcorn-types/base_types.ts
@@ -294,6 +294,17 @@ export type ViewTemplate = {
     queries: any,
     remote?: boolean
   ) => Promise<void>;
+
+  openDataStream?: (
+    table_id: number | undefined,
+    viewName: string,
+    fieldName: string,
+    fieldView: string,
+    user: any,
+    configuration: any,
+    targetOpts: any
+  ) => Promise<any>;
+
   getStringsForI18n?: (configuration?: any) => string[];
   default_state_form?: (arg0: { default_state: any }) => any;
   routes?: Record<string, Action>;

--- a/packages/server/serve.js
+++ b/packages/server/serve.js
@@ -477,6 +477,7 @@ const setupSocket = (subdomainOffset, ...servers) => {
 
   io.of("/datastream").on("connection", (socket) => {
     let dataStream = null;
+    let dataTarget = null;
     socket.on(
       "open_data_stream",
       async ([viewName, id, fieldName, fieldView, targetOpts], callback) => {
@@ -504,7 +505,11 @@ const setupSocket = (subdomainOffset, ...servers) => {
               targetOpts
             );
             dataStream = stream;
-            getState().log(5, `opened data stram`);
+            dataTarget = target;
+            getState().log(
+              5,
+              `opened data stram to: ${JSON.stringify(dataTarget)}`
+            );
             callback({ status: "ok", target });
           } catch (err) {
             getState().log(
@@ -544,7 +549,10 @@ const setupSocket = (subdomainOffset, ...servers) => {
             );
             callback({ status: "error", msg: err.message || "unknown error" });
           } else {
-            getState().log(5, "closed data stram");
+            getState().log(
+              5,
+              `closed data stram of: ${JSON.stringify(dataTarget)}`
+            );
             callback({ status: "ok" });
             dataStream = null;
           }
@@ -566,7 +574,10 @@ const setupSocket = (subdomainOffset, ...servers) => {
                 }`
               );
             } else {
-              getState().log(5, "closed data stram");
+              getState().log(
+                5,
+                `closed data stram of: ${JSON.stringify(dataTarget)}`
+              );
               dataStream = null;
             }
           });


### PR DESCRIPTION
- socket-io interface for the Recorder plugin
- should work for other stream targets, too, but right now only fileviews are checked
- there is only a method to open and return the stream
- the caller can do the writing and closing otherwise we would have to do all the fetching for every stream operation