### PR TITLE
symlink into the saltcorn node_modules dir for plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22948,6 +22948,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-global": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
+      "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
+      "dependencies": {
+        "global-dirs": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-global/node_modules/global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==",
+      "dependencies": {
+        "ini": "^1.3.4"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/resolve-url": {
       "version": "0.2.1",
       "dev": true,
@@ -27245,6 +27267,7 @@
       "version": "0.9.5-beta.2",
       "license": "MIT",
       "dependencies": {
+        "resolve-global": "^1.0.0",
         "semver": "^7.6.0"
       }
     },

--- a/packages/plugins-loader/package.json
+++ b/packages/plugins-loader/package.json
@@ -12,7 +12,8 @@
   "license": "MIT",
   "main": "index.js",
   "dependencies": {
-    "semver": "^7.6.0"
+    "semver": "^7.6.0",
+    "resolve-global": "^1.0.0"
   },
   "repository": "github:saltcorn/saltcorn",
   "publishConfig": {


### PR DESCRIPTION
- when plugins are loaded in a directory where the recursive module loading is not possible @saltcorn/data and @saltcorn/markup can't be resolved
- added a symlink on top of the plugins-folder directory for that