### PR TITLE
cache the plugin engine infos, reload when the sc version changes

### DIFF
--- a/packages/plugins-loader/stable_versioning.js
+++ b/packages/plugins-loader/stable_versioning.js
@@ -22,10 +22,10 @@ const doCheck = (pluginVersion, versionInfos, scVersion) => {
 
 /**
  * check if 'pluginVersion' is supported or find the latest supported version
- * @param {*} pluginVersion - wanted version
- * @param {*} versionInfos - version infos from the npm registry (resembles the package.json version).
+ * @param pluginVersion - wanted version
+ * @param versionInfos - version infos from the npm registry (resembles the package.json version).
  *                            Here you'll find the engines.saltcorn property.
- * @param {*} scVersion - saltcorn version
+ * @param scVersion - saltcorn version
  * @returns
  */
 const supportedVersion = (

--- a/packages/saltcorn-admin-models/models/tenant.ts
+++ b/packages/saltcorn-admin-models/models/tenant.ts
@@ -229,7 +229,11 @@ const create_tenant = async ({
 };
 
 const upgrade_all_tenants_plugins = async (
-  loadPlugin: (arg0: Plugin, arg1: boolean) => Promise<{ version: string }>
+  loadPlugin: (
+    arg0: Plugin,
+    arg1: boolean,
+    arg2: boolean
+  ) => Promise<{ version: string }>
 ): Promise<void> => {
   const tenantList = [db.connectObj.default_schema, ...(await getAllTenants())];
   const latest_versions: any = {};
@@ -247,7 +251,7 @@ const upgrade_all_tenants_plugins = async (
           } else {
             const prevVersion = plugin.version;
             plugin.version = "latest";
-            const { version } = await loadPlugin(plugin, true);
+            const { version } = await loadPlugin(plugin, true, true);
             getState().log(
               5,
               `Plugin ${plugin.location} latest version ${version} (previously ${prevVersion})`

--- a/packages/saltcorn-cli/src/commands/plugins.js
+++ b/packages/saltcorn-cli/src/commands/plugins.js
@@ -63,7 +63,7 @@ class PluginsCommand extends Command {
         const oldVersion = plugin.version;
         try {
           plugin.version = "latest";
-          await ensurePluginSupport(plugin);
+          await ensurePluginSupport(plugin, true);
           const { version } = await requirePlugin(plugin, true);
           //console.log(plinfo)
           if (version) new_versions[plugin.location] = version;

--- a/packages/saltcorn-data/db/state.ts
+++ b/packages/saltcorn-data/db/state.ts
@@ -563,9 +563,8 @@ class State {
   /**
    *
    * Set value of config parameter
-   * @param {string} key - key of parameter
-   * @param {*} value - value of parameter
-   * @returns {Promise<void>}
+   * @param key - key of parameter
+   * @param value - value of parameter
    */
   async setConfig(key: string, value: any) {
     if (
@@ -594,19 +593,23 @@ class State {
 
   /**
    * Delete config parameter by key
-   * @param {string} keys - key of parameter
-   * @returns {Promise<void>}
+   * @param keys - key of parameter
    */
   async deleteConfig(...keys: string[]) {
-    for (const key of keys) {
-      await deleteConfig(key);
-      delete this.configs[key];
-    }
-    if (db.is_node)
-      process_send({ refresh: "config", tenant: db.getTenantSchema() });
-    else {
-      await this.refresh_config(true);
-    }
+    const fn = async () => {
+      for (const key of keys) {
+        await deleteConfig(key);
+        delete this.configs[key];
+      }
+      if (db.is_node)
+        process_send({ refresh: "config", tenant: db.getTenantSchema() });
+      else {
+        await this.refresh_config(true);
+      }
+    };
+    if (db.getTenantSchema() !== this.tenant)
+      await db.runWithTenant(this.tenant, fn);
+    else await fn();
   }
 
   /**

--- a/packages/saltcorn-data/db/state.ts
+++ b/packages/saltcorn-data/db/state.ts
@@ -573,17 +573,22 @@ class State {
       typeof this.configs[key].value === "undefined" ||
       this.configs[key].value !== value
     ) {
-      await setConfig(key, value);
-      this.configs[key] = { value };
-      if (key.startsWith("localizer_")) await this.refresh_i18n();
-      if (key === "log_level") this.logLevel = +value;
-      if (key === "joined_log_socket_ids")
-        this.hasJoinedLogSockets = (value || []).length > 0;
-      if (db.is_node)
-        process_send({ refresh: "config", tenant: db.getTenantSchema() });
-      else {
-        await this.refresh_config(true);
-      }
+      const fn = async () => {
+        await setConfig(key, value);
+        this.configs[key] = { value };
+        if (key.startsWith("localizer_")) await this.refresh_i18n();
+        if (key === "log_level") this.logLevel = +value;
+        if (key === "joined_log_socket_ids")
+          this.hasJoinedLogSockets = (value || []).length > 0;
+        if (db.is_node)
+          process_send({ refresh: "config", tenant: db.getTenantSchema() });
+        else {
+          await this.refresh_config(true);
+        }
+      };
+      if (db.getTenantSchema() !== this.tenant)
+        await db.runWithTenant(this.tenant, fn);
+      else await fn();
     }
   }
 

--- a/packages/saltcorn-data/models/config.ts
+++ b/packages/saltcorn-data/models/config.ts
@@ -1001,6 +1001,17 @@ const configTypes: ConfigTypes = {
     root_only: true,
     restart_required: true,
   },
+  engines_cache: {
+    type: "JSON",
+    label: "Cached plugin version infos",
+    default: {},
+  },
+  // when this is different from the current version, the engines cache is cleared
+  engines_cache_sc_version: {
+    type: "String",
+    label: "Saltcorn version for engines cache",
+    default: "",
+  },
 };
 // TODO move list of languages from code to configuration
 const available_languages = {

--- a/packages/saltcorn-data/models/plugin.ts
+++ b/packages/saltcorn-data/models/plugin.ts
@@ -151,8 +151,10 @@ class Plugin {
   }
 
   ready_for_mobile(): boolean {
-    const { getState } = require("../db/state");
-    const module = getState().plugins[this.name];
+    const state = require("../db/state").getState();
+    let module = state.plugins[this.name];
+    if (!module && state.plugin_module_names[this.name])
+      module = state.plugins[state.plugin_module_names[this.name]];
     return module?.ready_for_mobile === true;
   }
 

--- a/packages/server/load_plugins.js
+++ b/packages/server/load_plugins.js
@@ -19,17 +19,46 @@ const {
   resolveLatest,
 } = require("@saltcorn/plugins-loader/stable_versioning");
 
+const isFixedPlugin = (plugin) =>
+  plugin.location === "@saltcorn/sbadmin2" ||
+  plugin.location === "@saltcorn/base-plugin";
+
+/**
+ * return the cached engine infos or fetch them from npm and update the cache
+ * @param plugin plugin to load
+ */
+const getEngineInfos = async (plugin) => {
+  const rootState = getRootState();
+  const cached = rootState.getConfig("engines_cache", {}) || {};
+  if (cached[plugin.location]) {
+    return cached[plugin.location];
+  } else {
+    getState().log(5, `Fetching versions for '${plugin.location}'`);
+    const pkgInfo = await npmFetch.json(
+      `https://registry.npmjs.org/${plugin.location}`
+    );
+    const versions = pkgInfo.versions;
+    const newCached = {};
+    for (const [k, v] of Object.entries(versions)) {
+      newCached[k] = v.engines?.saltcorn
+        ? { engines: { saltcorn: v.engines.saltcorn } }
+        : {};
+    }
+    cached[plugin.location] = newCached;
+    await rootState.setConfig("engines_cache", { ...cached });
+    return newCached;
+  }
+};
+
 /**
  * checks the saltcorn engine property and changes the plugin version if necessary
  * @param plugin plugin to load
  */
 const ensurePluginSupport = async (plugin) => {
-  const pkgInfo = await npmFetch.json(
-    `https://registry.npmjs.org/${plugin.location}`
-  );
+  const versions = await getEngineInfos(plugin);
   const supported = supportedVersion(
     plugin.version || "latest",
-    pkgInfo.versions,
+    versions,
     packagejson.version
   );
   if (!supported)
@@ -38,8 +67,7 @@ const ensurePluginSupport = async (plugin) => {
     );
   else if (
     supported !== plugin.version ||
-    (plugin.version === "latest" &&
-      supported !== resolveLatest(pkgInfo.versions))
+    (plugin.version === "latest" && supported !== resolveLatest(versions))
   )
     plugin.version = supported;
 };
@@ -51,7 +79,7 @@ const ensurePluginSupport = async (plugin) => {
  * @param force - force flag
  */
 const loadPlugin = async (plugin, force) => {
-  if (plugin.source === "npm" && isRoot()) {
+  if (plugin.source === "npm" && !isFixedPlugin(plugin)) {
     try {
       await ensurePluginSupport(plugin);
     } catch (e) {
@@ -279,6 +307,6 @@ module.exports = {
   loadAllPlugins,
   loadPlugin,
   requirePlugin,
-  supportedVersion,
+  getEngineInfos,
   ensurePluginSupport,
 };

--- a/packages/server/load_plugins.js
+++ b/packages/server/load_plugins.js
@@ -27,10 +27,10 @@ const isFixedPlugin = (plugin) =>
  * return the cached engine infos or fetch them from npm and update the cache
  * @param plugin plugin to load
  */
-const getEngineInfos = async (plugin) => {
+const getEngineInfos = async (plugin, forceFetch) => {
   const rootState = getRootState();
   const cached = rootState.getConfig("engines_cache", {}) || {};
-  if (cached[plugin.location]) {
+  if (cached[plugin.location] && !forceFetch) {
     return cached[plugin.location];
   } else {
     getState().log(5, `Fetching versions for '${plugin.location}'`);
@@ -54,8 +54,8 @@ const getEngineInfos = async (plugin) => {
  * checks the saltcorn engine property and changes the plugin version if necessary
  * @param plugin plugin to load
  */
-const ensurePluginSupport = async (plugin) => {
-  const versions = await getEngineInfos(plugin);
+const ensurePluginSupport = async (plugin, forceFetch) => {
+  const versions = await getEngineInfos(plugin, forceFetch);
   const supported = supportedVersion(
     plugin.version || "latest",
     versions,
@@ -78,10 +78,10 @@ const ensurePluginSupport = async (plugin) => {
  * @param plugin - plugin to load
  * @param force - force flag
  */
-const loadPlugin = async (plugin, force) => {
+const loadPlugin = async (plugin, force, forceFetch) => {
   if (plugin.source === "npm" && !isFixedPlugin(plugin)) {
     try {
-      await ensurePluginSupport(plugin);
+      await ensurePluginSupport(plugin, forceFetch);
     } catch (e) {
       console.log(
         `Warning: Unable to find a supported version for '${plugin.location}' Continuing with the installed version`

--- a/packages/server/routes/plugins.js
+++ b/packages/server/routes/plugins.js
@@ -1332,8 +1332,8 @@ router.get(
   error_catcher(async (req, res) => {
     const schema = db.getTenantSchema();
     if (schema === db.connectObj.default_schema) {
-      await upgrade_all_tenants_plugins((p, f) =>
-        load_plugins.loadPlugin(p, f)
+      await upgrade_all_tenants_plugins((p, f, forceFetch) =>
+        load_plugins.loadPlugin(p, f, forceFetch)
       );
       req.flash(
         "success",
@@ -1344,7 +1344,9 @@ router.get(
     } else {
       const installed_plugins = await Plugin.find({});
       for (const plugin of installed_plugins) {
-        await plugin.upgrade_version((p, f) => load_plugins.loadPlugin(p, f));
+        await plugin.upgrade_version((p, f, forceFetch) =>
+          load_plugins.loadPlugin(p, f, forceFetch)
+        );
       }
       req.flash("success", req.__(`Modules up-to-date`));
       await restart_tenant(loadAllPlugins);
@@ -1370,7 +1372,7 @@ router.get(
     const { name } = req.params;
 
     const plugin = await Plugin.findOne({ name });
-    const versions = await load_plugins.getEngineInfos();
+    const versions = await load_plugins.getEngineInfos(plugin, true);
 
     await plugin.upgrade_version(
       (p, f) => load_plugins.loadPlugin(p, f),

--- a/packages/server/routes/plugins.js
+++ b/packages/server/routes/plugins.js
@@ -1370,16 +1370,11 @@ router.get(
     const { name } = req.params;
 
     const plugin = await Plugin.findOne({ name });
-    const pkgInfo = await npmFetch.json(
-      `https://registry.npmjs.org/${plugin.location}`
-    );
+    const versions = await load_plugins.getEngineInfos();
+
     await plugin.upgrade_version(
       (p, f) => load_plugins.loadPlugin(p, f),
-      supportedVersion(
-        "latest",
-        pkgInfo.versions,
-        require("../package.json").version
-      )
+      supportedVersion("latest", versions, require("../package.json").version)
     );
     req.flash("success", req.__(`Module up-to-date`));
 


### PR DESCRIPTION
- added two configurations to cache the enigne infos
- 'engines_cache' caches engine infos of plugins 
- 'engines_cache_sc_version' stores the version with which the cache was build
- changed State.setConfig so that you can set a config on the root state from a tenant