### PR TITLE
validate mobile-app-result build dir

### DIFF
--- a/packages/server/locales/en.json
+++ b/packages/server/locales/en.json
@@ -1468,5 +1468,7 @@
 	"Time to run": "Time to run",
 	"Mobile": "Mobile",
 	"Plain password trigger row": "Plain password trigger row",
-	"Send plaintext password changes to Users table triggers (Insert, Update and Validate).": "Send plaintext password changes to Users table triggers (Insert, Update and Validate)."
+	"Send plaintext password changes to Users table triggers (Insert, Update and Validate).": "Send plaintext password changes to Users table triggers (Insert, Update and Validate).",
+	"Invalid build directory path": "Invalid build directory path",
+	"Invalid build directory name": "Invalid build directory name"
 }


### PR DESCRIPTION
- 1. check characters and format of only the build dir name
- 2. resolve full buildDir path and check it starts with ${rootFolder.location}/mobile_app