### PR TITLE
try force fetch when a plugin version is not in the cache

### DIFF
--- a/packages/server/load_plugins.js
+++ b/packages/server/load_plugins.js
@@ -55,7 +55,15 @@ const getEngineInfos = async (plugin, forceFetch) => {
  * @param plugin plugin to load
  */
 const ensurePluginSupport = async (plugin, forceFetch) => {
-  const versions = await getEngineInfos(plugin, forceFetch);
+  let versions = await getEngineInfos(plugin, forceFetch);
+  if (
+    plugin.version &&
+    plugin.version !== "latest" &&
+    !versions[plugin.version] &&
+    !forceFetch
+  ) {
+    versions = await getEngineInfos(plugin, true);
+  }
   const supported = supportedVersion(
     plugin.version || "latest",
     versions,

--- a/packages/server/routes/plugins.js
+++ b/packages/server/routes/plugins.js
@@ -1236,13 +1236,15 @@ router.get(
       update_permitted &&
       (await get_latest_npm_version(plugin_db.location, 1000));
     let engineInfos = await load_plugins.getEngineInfos(plugin_db); // with cache
-    if (latest && !engineInfos[latest])
-      engineInfos = await load_plugins.getEngineInfos(plugin_db, true); // force fetch
+    let forceFetch = true;
+    if (latest && !engineInfos[latest]) {
+      engineInfos = await load_plugins.getEngineInfos(plugin_db, forceFetch);
+      forceFetch = false;
+    }
     if (latest && !isVersionSupported(latest, engineInfos)) {
-      // with force fetch
       latest = supportedVersion(
         latest,
-        await load_plugins.getEngineInfos(plugin_db, true)
+        await load_plugins.getEngineInfos(plugin_db, forceFetch)
       );
     }
     const can_update = update_permitted && latest && mod.version !== latest;

--- a/packages/server/routes/plugins.js
+++ b/packages/server/routes/plugins.js
@@ -1235,10 +1235,10 @@ router.get(
     let latest =
       update_permitted &&
       (await get_latest_npm_version(plugin_db.location, 1000));
-    if (
-      latest &&
-      !isVersionSupported(latest, await load_plugins.getEngineInfos(plugin_db)) // with cache
-    ) {
+    let engineInfos = await load_plugins.getEngineInfos(plugin_db); // with cache
+    if (latest && !engineInfos[latest])
+      engineInfos = await load_plugins.getEngineInfos(plugin_db, true); // force fetch
+    if (latest && !isVersionSupported(latest, engineInfos)) {
       // with force fetch
       latest = supportedVersion(
         latest,


### PR DESCRIPTION
- when a plugin gets a new version it's not in the cache until the sc version changes
- added a force fetch retry
- #2735 