### PR TITLE
npm_prefix on spawn npm, apply fresh docker group

### DIFF
--- a/packages/install/index.js
+++ b/packages/install/index.js
@@ -463,9 +463,10 @@ echo 'export PATH=/home/saltcorn/.local/bin:$PATH' >> /home/saltcorn/.bashrc
   const { configFileDir } = get_paths(user);
 
   await asyncSudoUser(user, ["mkdir", "-p", configFileDir], false, dryRun);
+  const npmPrefix = `/home/${user}/.local/`;
   await asyncSudoUser(
     user,
-    ["npm", "config", "set", "prefix", `/home/${user}/.local/`],
+    ["npm", "config", "set", "prefix", npmPrefix],
     false,
     dryRun
   );
@@ -480,13 +481,15 @@ echo 'export PATH=/home/saltcorn/.local/bin:$PATH' >> /home/saltcorn/.bashrc
       "--unsafe",
     ],
     false,
-    dryRun
+    dryRun,
+    { npm_config_prefix: npmPrefix }
   );
   await asyncSudoUser(
     user,
     ["npm", "install", "-g", "sd-notify"],
     true,
-    dryRun
+    dryRun,
+    { npm_config_prefix: npmPrefix }
   );
   await asyncSudo(
     [

--- a/packages/install/index.js
+++ b/packages/install/index.js
@@ -738,7 +738,7 @@ WantedBy=multi-user.target`
   if (dockerMode) {
     try {
       await setupDocker(user, dockerMode, addToDockerGroup, osInfo, dryRun);
-      await pullCordovaBuilder(user, dockerMode, dryRun);
+      await pullCordovaBuilder(user, dockerMode, addToDockerGroup, dryRun);
       // restart to apply the docker group membership
       await asyncSudo(["systemctl", "restart", osService], false, dryRun);
     } catch (error) {

--- a/packages/install/utils.js
+++ b/packages/install/utils.js
@@ -95,7 +95,12 @@ const setupDocker = async (
   }
 };
 
-const pullCordovaBuilder = async (user, dockerMode, dryRun) => {
+const pullCordovaBuilder = async (
+  user,
+  dockerMode,
+  addToDockerGroup,
+  dryRun
+) => {
   if (dockerMode === "rootless") {
     await asyncSudo(
       [
@@ -111,12 +116,26 @@ const pullCordovaBuilder = async (user, dockerMode, dryRun) => {
       dryRun
     );
   } else if (dockerMode === "standard") {
-    await asyncSudoUser(
-      user,
-      ["docker", "pull", "saltcorn/cordova-builder"],
-      false,
-      dryRun
-    );
+    if (addToDockerGroup) {
+      await asyncSudo(
+        [
+          "bash",
+          "-c",
+          `newgrp docker <<EOF  
+  docker pull saltcorn/cordova-builder
+EOF`,
+        ],
+        false,
+        dryRun
+      );
+    } else {
+      await asyncSudoUser(
+        user,
+        ["docker", "pull", "saltcorn/cordova-builder"],
+        false,
+        dryRun
+      );
+    }
   } else throw new Error(`Unknown docker mode ${dockerMode}`);
 };
 

--- a/packages/install/utils.js
+++ b/packages/install/utils.js
@@ -185,12 +185,13 @@ const runDockerScript = async (dryRun) => {
  * @param dryRun - if true than it does not execute sudo but displays commands (to test purposes)
  * @returns {Promise<*>}
  */
-const asyncSudoUser = (user, args, allowFail, dryRun) => {
+const asyncSudoUser = (user, args, allowFail, dryRun, envVars = {}) => {
   if (os.userInfo().username === user) {
     console.log(">", args.join(" "));
     if (!dryRun)
       execSync(args.join(" "), {
         stdio: "inherit",
+        env: { ...process.env, ...envVars },
       });
   } else return asyncSudo(["sudo", "-iu", user, ...args], allowFail, dryRun);
 };


### PR DESCRIPTION
- when the prefix is set in the current process, the old prefix is still in the enviroment
- when the install script creates the docker group, we have to spawn docker with newgrp to see the group without relogin