### PR TITLE
encode filename and open inAppBrowser with _blank

### DIFF
--- a/packages/saltcorn-mobile-app/www/js/utils/iframe_view_utils.js
+++ b/packages/saltcorn-mobile-app/www/js/utils/iframe_view_utils.js
@@ -654,15 +654,16 @@ async function make_unique_field(
 }
 
 function openFile(fileId) {
-  // TODO fileIds with whitespaces do not work
   const config = parent.saltcorn.data.state.getState().mobileConfig;
   const serverPath = config.server_path;
   const token = config.jwt;
-  const url = `${serverPath}/files/serve/${fileId}?jwt=${token}`;
+  const url = `${serverPath}/files/serve/${encodeURIComponent(
+    fileId
+  )}?jwt=${token}`;
   parent.cordova.InAppBrowser.open(
     url,
-    "_self",
-    "clearcache=yes,clearsessioncache=yes,location=no"
+    "_blank",
+    "clearcache=yes,clearsessioncache=yes,location=no,toolbar=yes,toolbarposition=top"
   );
 }
 


### PR DESCRIPTION
- _blank opens a new standalone inAppBrowser instead of replacing the current view
- _system could propably handle more files, but this is the system browser and we can get conflicts with the connect.sid session
- I guess we should change this after v 1.0