### PR TITLE
API to serve files with bearer token

### DIFF
--- a/packages/server/routes/api.js
+++ b/packages/server/routes/api.js
@@ -27,6 +27,7 @@ const Table = require("@saltcorn/data/models/table");
 const View = require("@saltcorn/data/models/view");
 //const Field = require("@saltcorn/data/models/field");
 const Trigger = require("@saltcorn/data/models/trigger");
+const File = require("@saltcorn/data/models/file");
 //const load_plugins = require("../load_plugins");
 const passport = require("passport");
 

--- a/packages/server/tests/api.test.js
+++ b/packages/server/tests/api.test.js
@@ -379,7 +379,7 @@ describe("API authentication", () => {
     await request(app)
       .get("/api/serve-files/rick1.png")
       .set("Authorization", "Bearer " + u.api_token)
-      .status(200);
+      .expect(200);
   });
 });
 

--- a/packages/server/tests/api.test.js
+++ b/packages/server/tests/api.test.js
@@ -2,6 +2,8 @@ const request = require("supertest");
 const getApp = require("../app");
 const Table = require("@saltcorn/data/models/table");
 const Trigger = require("@saltcorn/data/models/trigger");
+const File = require("@saltcorn/data/models/file");
+const fs = require("fs").promises;
 
 const Field = require("@saltcorn/data/models/field");
 const {
@@ -19,6 +21,19 @@ const User = require("@saltcorn/data/models/user");
 
 beforeAll(async () => {
   await resetToFixtures();
+  await File.ensure_file_store();
+  await File.from_req_files(
+    {
+      mimetype: "image/png",
+      name: "rick1.png",
+      mv: async (fnm) => {
+        await fs.writeFile(fnm, "nevergonnagiveyouup");
+      },
+      size: 245752,
+    },
+    1,
+    80
+  );
 });
 afterAll(db.close);
 
@@ -351,6 +366,13 @@ describe("API authentication", () => {
       .set("Authorization", "Bearer " + u.api_token)
 
       .expect(succeedJsonWith((rows) => rows.length == 2));
+  });
+  it("should not show file to public", async () => {
+    const app = await getApp();
+    await request(app)
+      .get("/api/serve-files/rick1.png")
+      .expect(404)
+      .expect(respondJsonWith(404, (b) => b.error === "Not found"));
   });
 });
 

--- a/packages/server/tests/api.test.js
+++ b/packages/server/tests/api.test.js
@@ -371,7 +371,6 @@ describe("API authentication", () => {
     const app = await getApp();
     await request(app)
       .get("/api/serve-files/rick1.png")
-      .expect(404)
       .expect(respondJsonWith(404, (b) => b.error === "Not found"));
   });
 });

--- a/packages/server/tests/api.test.js
+++ b/packages/server/tests/api.test.js
@@ -373,6 +373,14 @@ describe("API authentication", () => {
       .get("/api/serve-files/rick1.png")
       .expect(respondJsonWith(404, (b) => b.error === "Not found"));
   });
+  it("should show file to user", async () => {
+    const app = await getApp();
+    const u = await User.findOne({ id: 1 });
+    await request(app)
+      .get("/api/serve-files/rick1.png")
+      .set("Authorization", "Bearer " + u.api_token)
+      .status(200);
+  });
 });
 
 describe("API action", () => {


### PR DESCRIPTION
This provides an API to serve files using the bearer token or access token in the query string

`/api/serve-files/{path/to/file}`