### PR TITLE
webpack externals, response mock status fn

### DIFF
--- a/packages/saltcorn-data/webpack.config.js
+++ b/packages/saltcorn-data/webpack.config.js
@@ -38,6 +38,10 @@ const dbMocks = {
 };
 
 module.exports = {
+  externals: {
+    "@saltcorn/sqlite": "@saltcorn/sqlite",
+    "@saltcorn/postgres": "@saltcorn/postgres",
+  },
   optimization: {
     minimize: false, // debug
     //runtimeChunk: "single",

--- a/packages/saltcorn-mobile-app/www/js/mocks/response.js
+++ b/packages/saltcorn-mobile-app/www/js/mocks/response.js
@@ -44,7 +44,7 @@ function MobileResponse() {
   }
 
   function getStatus() {
-    return status;
+    return resStatus;
   }
 
   return {


### PR DESCRIPTION
- don't bundle sqlite adn postgres pcks. Corodova has a plugins for the db
- fixed status function in mobile response mock