### PR TITLE
Fix `sync_table_from_external` to use tables with provider_name as source

### DIFF
--- a/packages/saltcorn-data/base-plugin/actions.js
+++ b/packages/saltcorn-data/base-plugin/actions.js
@@ -1504,7 +1504,7 @@ module.exports = {
      * @returns {Promise<object[]>}
      */
     description:
-      "Synchronize a database table with an external table by copying rows from the external table",
+      "Synchronize a database table with an external/provider table by copying rows from the external table",
     configFields: async ({ table }) => {
       const tables = await Table.find_with_external();
       const pk_options = {};
@@ -1518,14 +1518,14 @@ module.exports = {
           label: "Source table",
           sublabel: "External table to sync from",
           input_type: "select",
-          options: tables.filter((t) => t.external).map((t) => t.name),
+          options: tables.filter((t) => t.external || t.provider_name).map((t) => t.name),
         },
         {
           name: "table_dest",
           label: "Destination table",
           sublabel: "Table to sync to",
           input_type: "select",
-          options: tables.filter((t) => !t.external).map((t) => t.name),
+          options: tables.filter((t) => !(t.external || t.provider_name)).map((t) => t.name),
         },
         {
           name: "pk_field",


### PR DESCRIPTION
Fixes #2797