### PR TITLE
share_to target for PWA apps

### DIFF
--- a/packages/saltcorn-data/models/config.ts
+++ b/packages/saltcorn-data/models/config.ts
@@ -793,6 +793,12 @@ const configTypes: ConfigTypes = {
     default: "browser",
     options: ["browser", "fullscreen", "standalone", "minimal-ui"],
   },
+  pwa_share_to_enabled: {
+    type: "Bool",
+    label: "Share to enabled",
+    sublabel: "Enable the share to feature",
+    default: false,
+  },
   pwa_set_colors: {
     type: "Bool",
     label: "Set colors",

--- a/packages/saltcorn-data/models/trigger.ts
+++ b/packages/saltcorn-data/models/trigger.ts
@@ -531,6 +531,7 @@ class Trigger implements AbstractTrigger {
       "Error",
       "Startup",
       "UserVerified",
+      "ReceiveMobileShareData",
       ...Object.keys(getState().eventTypes),
     ];
   }

--- a/packages/server/app.js
+++ b/packages/server/app.js
@@ -74,7 +74,7 @@ const noCsrfLookup = (state) => {
   if (!state.plugin_routes) return null;
   else {
     const result = new Set();
-    for (const [plugin, routes] of Object.entries(state.plugin_routes)) {
+    for (const routes of Object.values(state.plugin_routes)) {
       for (const url of routes
         .filter((r) => r.noCsrf === true)
         .map((r) => r.url)) {
@@ -87,7 +87,7 @@ const noCsrfLookup = (state) => {
 
 const prepPluginRouter = (pluginRoutes) => {
   const router = express.Router();
-  for (const [plugin, routes] of Object.entries(pluginRoutes)) {
+  for (const routes of Object.values(pluginRoutes)) {
     for (const route of routes) {
       switch (route.method) {
         case "post":
@@ -366,7 +366,9 @@ const getApp = async (opts = {}) => {
             req.url === "/auth/login-with/jwt" ||
             req.url === "/auth/signup")) ||
         jwt_extractor(req) ||
-        req.url === "/auth/callback/saml"
+        req.url === "/auth/callback/saml" ||
+        req.url.startsWith("/notifications/share-handler") ||
+        req.url.startsWith("/notifications/manifest")
       )
         return disabledCsurf(req, res, next);
       csurf(req, res, next);

--- a/packages/server/routes/admin.js
+++ b/packages/server/routes/admin.js
@@ -3844,6 +3844,10 @@ admin_config_route({
     { section_header: "Progressive Web Application" },
     "pwa_enabled",
     { name: "pwa_display", showIf: { pwa_enabled: true } },
+    {
+      name: "pwa_share_to_enabled",
+      showIf: { pwa_enabled: true },
+    },
     { name: "pwa_set_colors", showIf: { pwa_enabled: true } },
     {
       name: "pwa_theme_color",


### PR DESCRIPTION
- supports POST shares
- a share triggers ReceiveMobileShareData with { title, text, url } as row payload