### PR TITLE
capacitor plugins array in saltcorn plugins and mobile code dir

### DIFF
--- a/packages/saltcorn-data/db/state.ts
+++ b/packages/saltcorn-data/db/state.ts
@@ -28,6 +28,7 @@ import {
   Action,
   AuthenticationMethod,
   CopilotSkill,
+  CapacitorPlugin,
 } from "@saltcorn/types/base_types";
 import { Type } from "@saltcorn/types/common_types";
 import type { ConfigTypes, SingleConfig } from "../models/config";
@@ -182,6 +183,7 @@ class State {
   waitingWorkflows?: boolean;
   keyframes: Array<string>;
   copilot_skills: Record<string, CopilotSkill>;
+  capacitorPlugins: Array<CapacitorPlugin>;
 
   private oldCodePages: Record<string, string> | undefined;
 
@@ -254,6 +256,7 @@ class State {
       "bounce",
       "tada",
     ];
+    this.capacitorPlugins = [];
   }
 
   processSend(v: any) {
@@ -838,6 +841,13 @@ class State {
     const routes = withCfg("routes", []);
     this.plugin_routes[name] = routes;
     if (routes.length > 0 && this.routesChangedCb) this.routesChangedCb();
+
+    withCfg("capacitor_plugins", []).forEach((capPlugin: CapacitorPlugin) => {
+      if (this.capacitorPlugins.find((cp) => cp.name === capPlugin.name))
+        this.log(5, `Capacitor plugin ${capPlugin.name} already registered`);
+      else this.capacitorPlugins.push(capPlugin);
+    });
+
     if (hasFunctions)
       this.refresh_codepages(true).catch((e) => console.error(e));
   }

--- a/packages/saltcorn-mobile-app/build_scripts/modify_android_manifest.js
+++ b/packages/saltcorn-mobile-app/build_scripts/modify_android_manifest.js
@@ -2,8 +2,19 @@ const { parseStringPromise, Builder } = require("xml2js");
 const { join } = require("path");
 const { readFileSync, writeFileSync } = require("fs");
 
+const readMobileConfig = () => {
+  console.log("Reading mobile config");
+  const content = readFileSync(
+    "/saltcorn-mobile-app/saltcorn-mobile-cfg.json",
+    "utf8"
+  );
+  console.log(content);
+  return JSON.parse(content);
+};
+
 (async () => {
   try {
+    const { permissions, features } = readMobileConfig();
     const androidManifest = join(
       "android",
       "app",
@@ -14,17 +25,12 @@ const { readFileSync, writeFileSync } = require("fs");
     const content = readFileSync(androidManifest);
     const parsed = await parseStringPromise(content);
 
-    parsed.manifest["uses-permission"] = [
-      { $: { "android:name": "android.permission.READ_EXTERNAL_STORAGE" } },
-      { $: { "android:name": "android.permission.WRITE_EXTERNAL_STORAGE" } },
-      { $: { "android:name": "android.permission.INTERNET" } },
-      { $: { "android:name": "android.permission.CAMERA" } },
-      { $: { "android:name": "android.permission.ACCESS_COARSE_LOCATION" } },
-      { $: { "android:name": "android.permission.ACCESS_FINE_LOCATION" } },
-    ];
-    parsed.manifest["uses-feature"] = [
-      { $: { "android:name": "android.hardware.location.gps" } },
-    ];
+    parsed.manifest["uses-permission"] = permissions.map((p) => ({
+      $: { "android:name": p },
+    }));
+    parsed.manifest["uses-feature"] = features.map((f) => ({
+      $: { "android:name": f },
+    }));
 
     parsed.manifest.application[0].$ = {
       ...parsed.manifest.application[0].$,

--- a/packages/saltcorn-mobile-app/src/helpers/common.js
+++ b/packages/saltcorn-mobile-app/src/helpers/common.js
@@ -2,7 +2,6 @@
 
 import { apiCall } from "./api";
 import { Camera, CameraResultType } from "@capacitor/camera";
-import { Geolocation } from "@capacitor/geolocation";
 import { ScreenOrientation } from "@capacitor/screen-orientation";
 import { SendIntent } from "send-intent";
 
@@ -163,17 +162,6 @@ export async function takePhoto() {
         msg: error.message ? error.message : "An error occured.",
       },
     ]);
-    return null;
-  }
-}
-
-export async function getGeolocation(successCb, errorCb) {
-  try {
-    const coordinates = await Geolocation.getCurrentPosition();
-    if (successCb) successCb(coordinates);
-    return coordinates;
-  } catch (error) {
-    if (errorCb) errorCb(error);
     return null;
   }
 }

--- a/packages/saltcorn-mobile-app/src/index.js
+++ b/packages/saltcorn-mobile-app/src/index.js
@@ -8,6 +8,13 @@ import * as offlineMode from "./helpers/offline_mode";
 import * as dbSchema from "./helpers/db_schema";
 import { router } from "./routing/index";
 
+const plugins = {};
+const context = require.context("./plugins-code", true, /index\.js$/);
+context.keys().forEach((key) => {
+  const pluginName = key.split("/")[1];
+  plugins[pluginName] = context(key);
+});
+
 export const mobileApp = {
   init,
   api,
@@ -17,4 +24,5 @@ export const mobileApp = {
   navigation: { ...navigation, router },
   offlineMode,
   dbSchema,
+  plugins,
 };

--- a/packages/saltcorn-mobile-builder/docker/Dockerfile
+++ b/packages/saltcorn-mobile-builder/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:18
 
-RUN apt update && apt install -y wget unzip
+RUN apt update && apt install -y wget unzip jq
 RUN apt install -y openjdk-17-jdk
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 

--- a/packages/saltcorn-mobile-builder/docker/entry.bash
+++ b/packages/saltcorn-mobile-builder/docker/entry.bash
@@ -1,13 +1,14 @@
 #!/bin/bash
 
 set -e
+cd /saltcorn-mobile-app
 
-BUILD_TYPE="$1"
-APP_VERSION="$2"
-SERVER_DOMAIN="$3"
-KEYSTORE_FILE="$4"
-KEYSTORE_ALIAS="$5"
-KEYSTORE_PASSWORD="$6"
+BUILD_TYPE=$(jq -r '.buildType' saltcorn-mobile-cfg.json)
+APP_VERSION=$(jq -r '.appVersion' saltcorn-mobile-cfg.json)
+SERVER_DOMAIN=$(jq -r '.serverDomain' saltcorn-mobile-cfg.json)
+KEYSTORE_FILE=$(jq -r '.keystoreFile' saltcorn-mobile-cfg.json)
+KEYSTORE_ALIAS=$(jq -r '.keystoreAlias' saltcorn-mobile-cfg.json)
+KEYSTORE_PASSWORD=$(jq -r '.keystorePassword' saltcorn-mobile-cfg.json)
 
 echo "BUILD_TYPE: $BUILD_TYPE"
 echo "APP_VERSION: $APP_VERSION"
@@ -20,10 +21,6 @@ export ANDROID_SDK_ROOT=/android_sdk
 export ANDROID_HOME=/android_sdk
 export GRADLE_HOME=/opt/gradle-8.4
 export PATH=$PATH:/opt/gradle-8.4/bin
-
-cd /saltcorn-mobile-app
-npm install @capacitor/cli@6.2.0 @capacitor/core@6.2.0 @capacitor/android@6.2.0
-npx cap sync
 
 # data extraction rules
 cat <<EOF > /saltcorn-mobile-app/android/app/src/main/res/xml/data_extraction_rules.xml

--- a/packages/saltcorn-mobile-builder/utils/package-bundle-utils.ts
+++ b/packages/saltcorn-mobile-builder/utils/package-bundle-utils.ts
@@ -128,3 +128,23 @@ export async function copyPublicDirs(buildDir: string) {
     }
   }
 }
+
+/*
+  Copy 'mobile-app' directories from pluginDir to buildDir in:
+  buildDir/src/plugins-code/[plugin_name]
+*/
+export function copyMobileAppDirs(buildDir: string) {
+  const state = getState();
+  const srcDir = join(buildDir, "src");
+  for (const k of Object.keys(state.plugins)) {
+    const location = state.plugin_locations[k];
+    if (location) {
+      const mobileAppDir = join(location, "mobile-app");
+      if (existsSync(mobileAppDir)) {
+        copySync(mobileAppDir, join(srcDir, "plugins-code", k), {
+          recursive: true,
+        });
+      }
+    }
+  }
+}

--- a/packages/saltcorn-types/base_types.ts
+++ b/packages/saltcorn-types/base_types.ts
@@ -500,6 +500,13 @@ export type CopilotSkill = {
   execute: (config: GenObj) => Promise<{ postExec?: string } | void>;
 };
 
+export type CapacitorPlugin = {
+  name: string;
+  version: string;
+  androidPermissions?: string[];
+  androidFeatures?: string[];
+};
+
 type PluginFacilities = {
   headers?: Array<Header>;
   functions?: PluginFunction | Function;


### PR DESCRIPTION
- a plugin can specify which capacitor plugins are needed
- a plugin can have a mobile-app dir with esm code that will be bundled into the app index.js has to be the entry point