### PR TITLE
allow v8 in run_code, when enabled in the dev settings

### DIFF
--- a/packages/saltcorn-data/db/state.ts
+++ b/packages/saltcorn-data/db/state.ts
@@ -1099,6 +1099,9 @@ class State {
               "url",
               "zlib",
               "v8",
+              "http2",
+              "path",
+              "tls",
             ].includes(moduleName)
           ) {
             if (process.env.IGNORE_DYNAMIC_REQUIRE !== "true") {

--- a/packages/saltcorn-data/db/state.ts
+++ b/packages/saltcorn-data/db/state.ts
@@ -1098,6 +1098,7 @@ class State {
               "stream",
               "url",
               "zlib",
+              "v8",
             ].includes(moduleName)
           ) {
             if (process.env.IGNORE_DYNAMIC_REQUIRE !== "true") {


### PR DESCRIPTION
- the live-plugin-manager returns {}
- propably because it's a build in
- #3233 