### PR TITLE
emit dynamic updates from run_js_code actions

### DIFF
--- a/packages/saltcorn-data/base-plugin/actions.js
+++ b/packages/saltcorn-data/base-plugin/actions.js
@@ -77,6 +77,11 @@ const consoleInterceptor = (state) => {
   };
 };
 
+const emit_to_client = (data) => {
+  const state = getState();
+  state.emitDynamicUpdate(db.getTenantSchema(), data);
+};
+
 /**
  * @param opts
  * @param opts.row
@@ -170,6 +175,7 @@ const run_code = async ({
     sleep,
     fetchJSON,
     fetch,
+    emit_to_client,
     run_js_code,
     tryCatchInTransaction: db.tryCatchInTransaction,
     commitAndRestartTransaction: db.commitAndRestartTransaction,

--- a/packages/saltcorn-data/db/state.ts
+++ b/packages/saltcorn-data/db/state.ts
@@ -1085,16 +1085,41 @@ class State {
     globalLogEmitter = f;
   }
 
+  /**
+   * @param f Function to emit collaborative editing messages
+   */
   setCollabEmitter(f: Function) {
     globalCollabEmitter = f;
+  }
+
+  /**
+   * @param f Function to emit dynamic update messages triggered from run_js_code actions
+   */
+  setDynamicUpdateEmitter(f: Function) {
+    globalDynamicUpdateEmitter = f;
   }
 
   emitLog(ten: string, min_level: number, msg: string) {
     globalLogEmitter(ten, min_level, msg);
   }
 
-  emitRealTimeUpdate(ten: string, type: string, data: any) {
+  /**
+   * For collaborative editing
+   * @param ten
+   * @param type
+   * @param data
+   */
+  emitCollabMessage(ten: string, type: string, data: any) {
     globalCollabEmitter(ten, type, data);
+  }
+
+  /**
+   * For dynamic updates triggered from a run_js_code action
+   * @param ten
+   * @param data
+   */
+  emitDynamicUpdate(ten: string, data: any) {
+    globalDynamicUpdateEmitter(ten, data);
   }
 
   // default auth methods to enabled
@@ -1202,6 +1227,7 @@ class State {
 let globalRoomEmitter: Function = () => {};
 let globalLogEmitter: Function = () => {};
 let globalCollabEmitter: Function = () => {};
+let globalDynamicUpdateEmitter: Function = () => {};
 
 // the root tenant's state is singleton
 const singleton = new State("public");

--- a/packages/saltcorn-data/models/view.ts
+++ b/packages/saltcorn-data/models/view.ts
@@ -973,7 +973,7 @@ class View implements AbstractView {
     const { getState } = require("../db/state");
     const state = getState();
     const withViewName = this.getRealTimeEventName(eventType);
-    state.emitRealTimeUpdate(db.getTenantSchema(), withViewName, data);
+    state.emitCollabMessage(db.getTenantSchema(), withViewName, data);
   }
 
   /**

--- a/packages/server/wrapper.js
+++ b/packages/server/wrapper.js
@@ -281,6 +281,7 @@ const get_headers = (req, version_tag, description, extras = []) => {
     { script: `/static_assets/${version_tag}/saltcorn-common.js` },
     { script: `/static_assets/${version_tag}/saltcorn.js` },
     { script: `/static_assets/${version_tag}/dayjs.min.js` },
+    { script: `/static_assets/${version_tag}/socket.io.min.js` },
   ];
   if (locale !== "en") {
     stdHeaders.push({


### PR DESCRIPTION
- added emit_to_client() function to the run_js_code context
- it takes a data object which will be used by common_done
- open or reuse an open socket io connection