### PR TITLE
no_saveandcontinue flag to skip form.trigger('change')

### DIFF
--- a/packages/saltcorn-data/base-plugin/viewtemplates/edit.js
+++ b/packages/saltcorn-data/base-plugin/viewtemplates/edit.js
@@ -998,24 +998,7 @@ const realTimeScript = (viewname, table_id, row) => {
       '${view.getRealTimeEventName(`UPDATE_EVENT?id=${rowId}`)}': (data) => {
         console.log("Update event received for view ${viewname}", data);
         if (data.updates) {
-          const form = $(\`form[data-viewname="${viewname}"]\`);
-          const safeFields = {};
-          if (form.length) {
-            for (const k of Object.keys(data.updates)) {
-              const input = form.find(
-                \`input[name=\${k}], textarea[name=\${k}], select[name=\${k}]\`
-              );
-              if (input.attr("no-real-time-update")) {
-                input.removeAttr("no-real-time-update");
-              }
-              else {
-                safeFields[k] = data.updates[k];
-              }
-            }
-          }
-          if (Object.keys(safeFields).length > 0) {
-            common_done({set_fields: safeFields}, "${viewname}")
-          }
+          common_done({set_fields: data.updates, no_onchange: true}, "${viewname}");
         }
       }
     }

--- a/packages/server/public/saltcorn-common.js
+++ b/packages/server/public/saltcorn-common.js
@@ -1841,7 +1841,7 @@ async function common_done(res, viewnameOrElem0, isWeb = true) {
         input.trigger("set_form_field");
       });
     }
-    form.trigger("change");
+    if (!res.no_onchange) form.trigger("change");
   }
 
   if (res.download) {

--- a/packages/server/public/saltcorn.js
+++ b/packages/server/public/saltcorn.js
@@ -512,12 +512,10 @@ function saveAndContinue(e, k, event) {
     return;
   var form = $(e).closest("form");
 
-  let inputEl = event?.target || event?.srcElement;
   let focusedEl = null;
   if (!event || !event.srcElement) {
     const el = form.find("select[sc-received-focus]")[0];
     if (el) {
-      inputEl = el;
       el.removeAttribute("sc-received-focus");
       if (el.getAttribute("previous-val") === el.value) return;
     }
@@ -534,7 +532,6 @@ function saveAndContinue(e, k, event) {
   var url = form.attr("action");
   var form_data = form.serialize();
   ajax_indicator(true, e);
-  if (inputEl) inputEl.setAttribute("no-real-time-update", true);
   $.ajax(url, {
     type: "POST",
     headers: {


### PR DESCRIPTION
- set input values from real-time updates without to trigger a save