### PR TITLE
disabled menu items on mobile

### DIFF
--- a/packages/saltcorn-data/standard-menu.js
+++ b/packages/saltcorn-data/standard-menu.js
@@ -1,5 +1,4 @@
 const create_standard_menu = async () => {
-
   const { getState } = require("./db/state");
 
   const state = getState();
@@ -39,7 +38,7 @@ const create_standard_menu = async () => {
       min_role: Math.max(canEditTables, canInspectTables),
       admin_page: "Tables",
       target_blank: false,
-      disable_on_mobile: false,
+      disable_on_mobile: true,
     },
     {
       href: "",
@@ -57,7 +56,7 @@ const create_standard_menu = async () => {
       min_role: canEditViews,
       admin_page: "Views",
       target_blank: false,
-      disable_on_mobile: false,
+      disable_on_mobile: true,
     },
     {
       href: "",
@@ -75,7 +74,7 @@ const create_standard_menu = async () => {
       min_role: canEditPages,
       admin_page: "Pages",
       target_blank: false,
-      disable_on_mobile: false,
+      disable_on_mobile: true,
     },
     {
       href: "",
@@ -201,7 +200,7 @@ const create_standard_menu = async () => {
         },
       ],
       user_menu_header: false,
-      disable_on_mobile: false,
+      disable_on_mobile: true,
     },
     ...(allow_signup
       ? [
@@ -221,7 +220,7 @@ const create_standard_menu = async () => {
             min_role: "100",
             user_page: "Signup",
             target_blank: false,
-            disable_on_mobile: false,
+            disable_on_mobile: true,
           },
         ]
       : []),
@@ -243,7 +242,7 @@ const create_standard_menu = async () => {
             min_role: "100",
             user_page: "Login",
             target_blank: false,
-            disable_on_mobile: false,
+            disable_on_mobile: true,
           },
         ]
       : []),
@@ -280,7 +279,7 @@ const create_standard_menu = async () => {
                 min_role: "80",
                 user_page: "Notifications",
                 target_blank: false,
-                disable_on_mobile: false,
+                disable_on_mobile: true,
               },
             ]
           : []),
@@ -300,7 +299,7 @@ const create_standard_menu = async () => {
           min_role: "80",
           user_page: "User settings",
           target_blank: false,
-          disable_on_mobile: false,
+          disable_on_mobile: true,
         },
         {
           href: "",
@@ -318,11 +317,11 @@ const create_standard_menu = async () => {
           min_role: "80",
           user_page: "Logout",
           target_blank: false,
-          disable_on_mobile: false,
+          disable_on_mobile: true,
         },
       ],
       user_menu_header: true,
-      disable_on_mobile: false,
+      disable_on_mobile: true,
     },
   ];
 

--- a/packages/saltcorn-data/web-mobile-commons.ts
+++ b/packages/saltcorn-data/web-mobile-commons.ts
@@ -26,7 +26,27 @@ const { getForm } = viewableFields;
 const MarkdownIt = require("markdown-it"),
   md = new MarkdownIt();
 
-const disabledMobileMenus = ["Action", "Search"];
+const disabledMobileMenus = ["Action", "Search", "Admin Page", "User Page"];
+
+const legacyMenuChecks = (item: any) => {
+  if (
+    item.type === "Header" &&
+    item.label === "Settings" &&
+    item.subitems?.length > 0 &&
+    item.subitems[0].type === "Admin Page"
+  ) {
+    return false;
+  }
+  if (
+    item.type === "Header" &&
+    item.label === "User" &&
+    item.subitems?.length > 0 &&
+    item.subitems[0].type === "User Page"
+  ) {
+    return false;
+  }
+  return true;
+};
 
 /**
  * Get extra menu
@@ -54,7 +74,8 @@ const get_extra_menu = (
         is_node
           ? true
           : disabledMobileMenus.indexOf(item.type) < 0 &&
-            !item.disable_on_mobile
+            !item.disable_on_mobile &&
+            legacyMenuChecks(item)
       )
       .map((item: any) => {
         const wrapUrl = (url: string) => {


### PR DESCRIPTION
- standard menu will set disabled_on_mobile to false but when you already migrated, the filter checks are needed