### PR TITLE
no clear engines cache after upgrade

### DIFF
--- a/packages/saltcorn-data/models/config.ts
+++ b/packages/saltcorn-data/models/config.ts
@@ -1360,13 +1360,6 @@ const configTypes: ConfigTypes = {
     default: {},
     excludeFromMobile: true,
   },
-  // when this is different from the current version, the engines cache is cleared
-  engines_cache_sc_version: {
-    type: "String",
-    label: "Saltcorn version for engines cache",
-    default: "",
-    excludeFromMobile: true,
-  },
   delete_finished_workflows_days: {
     type: "Integer",
     label: "Delete finished workflows after days",

--- a/packages/server/serve.js
+++ b/packages/server/serve.js
@@ -80,17 +80,6 @@ const ensureJwtSecret = () => {
 };
 
 /**
- * Ensure the engines cache is up to date with the current sc version
- */
-const ensureEnginesCache = async () => {
-  const cacheScVersion = await getConfig("engines_cache_sc_version", "");
-  if (!cacheScVersion || cacheScVersion !== getState().scVersion) {
-    await setConfig("engines_cache", {});
-    await setConfig("engines_cache_sc_version", getState().scVersion);
-  }
-};
-
-/**
  * validate all plugins folders and remove invalid entries
  * A folder is invalid when it has dependencies but not node_modules directory
  */
@@ -323,7 +312,6 @@ module.exports =
   } = {}) => {
     if (cluster.isMaster) {
       ensureJwtSecret();
-      await ensureEnginesCache();
       await ensurePluginsFolder();
       await ensureNotificationSubscriptions();
     }


### PR DESCRIPTION
- removed engines cache version and no clear cache on version mismatch
- don't clear the cache on startup after saltcorn was updated
- #3465 