### PR TITLE
esm & cjs dual module support

### DIFF
--- a/packages/plain-date/esm/index.js
+++ b/packages/plain-date/esm/index.js
@@ -1,12 +1,11 @@
 class PlainDate {
   constructor(year, month, day) {
     if (arguments.length === 0) {
-      const now = new Date();
+      const now = /* @__PURE__ */ new Date();
       this.year = now.getFullYear();
       this.month = now.getMonth() + 1;
       this.day = now.getDate();
     } else if (arguments.length === 1 && typeof year === "string") {
-      // Accept ISO date string
       const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(year);
       if (!match) throw new Error("Invalid date string");
       [, year, month, day] = match.map(Number);
@@ -32,14 +31,12 @@ class PlainDate {
     }
     if (!this.isValid()) this.is_invalid = true;
   }
-
   copyFromPlainDate(pd) {
     this.year = pd.year;
     this.month = pd.month;
     this.day = pd.day;
     this.is_invalid = pd.is_invalid;
   }
-
   static from(dateLike) {
     if (dateLike instanceof PlainDate)
       return new PlainDate(dateLike.year, dateLike.month, dateLike.day);
@@ -48,38 +45,27 @@ class PlainDate {
     if (typeof dateLike === "number") return new PlainDate(dateLike);
     throw new Error("Invalid dateLike");
   }
-
   static parse(dateStr) {
     return new PlainDate(Date.parse(dateStr));
   }
-
   static fromDate(date) {
     return new PlainDate(date);
   }
-
   isValid() {
     if (this.is_invalid) return false;
-    if (
-      !Number.isInteger(this.year) ||
-      !Number.isInteger(this.month) ||
-      !Number.isInteger(this.day)
-    )
+    if (!Number.isInteger(this.year) || !Number.isInteger(this.month) || !Number.isInteger(this.day))
       return false;
     if (this.month < 1 || this.month > 12) return false;
     const d = new Date(this.year, this.month - 1, this.day);
-    return (
-      d.getFullYear() === this.year &&
-      d.getMonth() + 1 === this.month &&
-      d.getDate() === this.day
-    );
+    return d.getFullYear() === this.year && d.getMonth() + 1 === this.month && d.getDate() === this.day;
   }
-
   getFullYear() {
     return this.year;
   }
   getMonth() {
     return this.month - 1;
-  } // 0-based like Date
+  }
+  // 0-based like Date
   getDate() {
     return this.day;
   }
@@ -89,7 +75,6 @@ class PlainDate {
   getTime() {
     return this.toDate().getTime();
   }
-
   toString() {
     if (this.is_invalid) return "Invalid Date";
     return this.toISODateString();
@@ -105,50 +90,41 @@ class PlainDate {
     if (this.is_invalid) throw new RangeError("Invalid time value");
     return `${String(this.year).padStart(4, "0")}-${String(this.month).padStart(2, "0")}-${String(this.day).padStart(2, "0")}`;
   }
-
   valueOf() {
     if (this.is_invalid) return NaN;
     return Date.UTC(this.year, this.month - 1, this.day);
   }
-
   equals(other) {
     const d = PlainDate.from(other);
     return this.year === d.year && this.month === d.month && this.day === d.day;
   }
-
   addDays(days) {
     const d = new Date(this.year, this.month - 1, this.day + days);
     return PlainDate.fromDate(d);
   }
-
   // Setters: always return a new PlainDate with overflow handled
   setMonth(month, day = this.day) {
-    // month: 0-based, like Date
     const d = new Date(this.year, month, day);
     this.copyFromPlainDate(PlainDate.fromDate(d));
     return this.getTime();
   }
-
   setDate(day) {
     const d = this.toDate();
     d.setDate(day);
     this.copyFromPlainDate(PlainDate.fromDate(d));
     return this.getTime();
   }
-
   setYear(year) {
     const d = new Date(year, this.month - 1, this.day);
     this.copyFromPlainDate(PlainDate.fromDate(d));
     return this.getTime();
   }
-
   toJSON() {
     if (this.is_invalid) return null;
     return this.toISODateString();
   }
-
   toDate() {
-    if (this.is_invalid) return new Date("Invalid Date");
+    if (this.is_invalid) return /* @__PURE__ */ new Date("Invalid Date");
     return new Date(this.year, this.month - 1, this.day);
   }
   toLocaleDateString(...args) {
@@ -157,19 +133,14 @@ class PlainDate {
   toLocaleString(...args) {
     return this.toDate().toLocaleString(...args);
   }
-
-  toLocaleDate(
-    locale = Intl.DateTimeFormat().resolvedOptions().locale,
-    options = {}
-  ) {
+  toLocaleDate(locale = Intl.DateTimeFormat().resolvedOptions().locale, options = {}) {
     if (this.is_invalid) return "Invalid Date";
     const defaultOptions = { year: "numeric", month: "long", day: "numeric" };
     return this.toDate().toLocaleDateString(locale, {
       ...defaultOptions,
-      ...options,
+      ...options
     });
   }
-
   toUTCString() {
     if (this.is_invalid) return "Invalid Date";
     let locale = Intl.DateTimeFormat().resolvedOptions().locale || "en-GB";
@@ -179,16 +150,14 @@ class PlainDate {
       day: "numeric",
       month: "short",
       year: "numeric",
-      timeZone: "UTC",
+      timeZone: "UTC"
     });
   }
-
   toUTCDate() {
     if (this.is_invalid) return "Invalid Date";
     const date = new Date(Date.UTC(this.year, this.month - 1, this.day));
     return date.toISOString().split("T")[0];
   }
-
   [Symbol.toPrimitive](hint) {
     if (hint === "number") {
       return this.getTime();
@@ -199,5 +168,8 @@ class PlainDate {
     return null;
   }
 }
-
-module.exports = PlainDate;
+var index_default = PlainDate;
+export {
+  PlainDate,
+  index_default as default
+};

--- a/packages/plain-date/esm/package.json
+++ b/packages/plain-date/esm/package.json
@@ -1,0 +1,7 @@
+{
+  "type": "module",
+  "name": "plain-date",
+  "exports": {
+    ".": "./index.js"
+  }
+}

--- a/packages/plain-date/package.json
+++ b/packages/plain-date/package.json
@@ -11,9 +11,14 @@
   "scripts": {
     "test": "jest",
     "tsc": "tsc -p tsconfig.json",
-    "clean": "echo 'No TypeScript build'"
+    "clean": "echo 'No TypeScript build'",
+    "test-cjs": "node test.js",
+    "cjs-build": "esbuild ./index.js --format=cjs --outfile=index.cjs",
+    "esm-build": "esbuild ./index.js --format=esm --outfile=esm/index.js"
   },
-  "dependencies": {},
+  "dependencies": {
+    "esbuild": "^0.25.9"
+  },
   "author": "Tom Nielsen",
   "license": "MIT",
   "jest": {
@@ -29,8 +34,23 @@
       "/plugins_folder/"
     ]
   },
-  "main": "index.js",
-  "publishConfig": {
-    "access": "public"
+  "type": "commonjs",
+  "main": "./index.js",
+  "module": "./esm/index.js",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./esm/index.js"
+      },
+      "require": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      }
+    }
+  },
+  "types": "./index.d.ts",
+  "bugs": {
+    "url": "https://github.com/saltcorn/saltcorn/issues"
   }
 }


### PR DESCRIPTION
### Summary
- Ship plain-date as a dual package (native ESM + CJS) without a build step so both import and require work out of the box.

### What changed
- Add native ESM entry: index.mjs
- Keep CJS entry: index.js
- package.json exports: "import" → ./esm/index.mjs, "require" → ./index.js
- Single types file: index.d.ts referenced by both conditions

### Notes
- TypeScript sometimes emits .mjs files with CJS syntax(https://mayank.co/blog/dual-packages/); unless we define type: "commonjs" in package.json

### What should be functioning
- require("@saltcorn/plain-date") → CJS works
- import ... from "@saltcorn/plain-date" → ESM works

### Browser / CDN (TODO)
- Still need to determine browser/CDN support. Exports + .mjs may not be usable directly via unpkg/jsdelivr without a browser-friendly bundle.
- Options: publish a UMD or an extra ESM bundle under dist/ for CDN usage, or rely on third-party CDNs that convert packages (esm.sh, skypack).