### PR TITLE
Issue/3508 reduce modules assets

### DIFF
--- a/packages/saltcorn-data/db/state.ts
+++ b/packages/saltcorn-data/db/state.ts
@@ -169,6 +169,7 @@ class State {
   layouts: Record<string, PluginLayout>;
   userLayouts: Record<string, PluginLayout>;
   headers: Record<string, Array<Header>>;
+  assets_by_role: Record<string, Array<Header>>;
   function_context: Record<string, Function>;
   codepage_context: Record<string, unknown>;
   plugins_cfg_context: any;
@@ -228,6 +229,7 @@ class State {
     this.layouts = { emergency: emergency_layout };
     this.userLayouts = {};
     this.headers = {};
+    this.assets_by_role = {};
     this.function_context = { moment, slugify: db.slugify };
     this.functions = { moment, slugify: db.slugify };
     this.plugins_cfg_context = {};
@@ -265,6 +267,67 @@ class State {
       "tada",
     ];
     this.capacitorPlugins = [];
+  }
+
+  async computeAssetsByRole() {
+    this.assets_by_role = {};
+    let roleIds: number[] = [];
+    const Role = (await import("../models/role")).default;
+    const roles = await Role.find({}, { orderBy: "role_id" });
+    roleIds = roles
+      .map((r: any) => +r.id)
+      .filter((n: number) => !Number.isNaN(n));
+
+    if (!roleIds.includes(100)) roleIds.push(100);
+    for (const rid of roleIds) this.assets_by_role[rid] = [];
+
+    const allHeaders = Object.values(this.headers).flat();
+    console.log({ allHeaders }, "HEADERS");
+    for (const h of allHeaders) {
+      if (!h.onlyViews && !h.onlyFieldviews) {
+        for (const rid of roleIds) this.assets_by_role[rid].push(h);
+        continue;
+      }
+
+      const onlyViews = h.onlyViews
+        ? Array.isArray(h.onlyViews)
+          ? h.onlyViews
+          : [h.onlyViews]
+        : [];
+
+      const onlyFieldviews = h.onlyFieldviews
+        ? Array.isArray(h.onlyFieldviews)
+          ? h.onlyFieldviews
+          : [h.onlyFieldviews]
+        : [];
+
+      const matchedViews = this.views.filter((v: any) => {
+        if (onlyViews.length) {
+          const tmplName = v.viewtemplateObj?.name || v.viewtemplate;
+          if (
+            onlyViews.includes(tmplName) ||
+            onlyViews.includes(v.viewtemplate)
+          )
+            return true;
+        }
+        if (onlyFieldviews.length) {
+          // Coming to this later
+        }
+        return false;
+      });
+
+      for (const v of matchedViews) {
+        const min_role = +(v.min_role ?? 100);
+        for (const rid of roleIds) {
+          if (rid <= min_role) this.assets_by_role[rid].push(h);
+        }
+      }
+    }
+
+    for (const ridStr of Object.keys(this.assets_by_role)) {
+      const rid = +ridStr;
+      this.assets_by_role[rid] = Array.from(new Set(this.assets_by_role[rid]));
+    }
   }
 
   processSend(v: any) {
@@ -530,6 +593,12 @@ class State {
         );
         this.virtual_triggers.push(...trs);
       }
+    }
+    // rebuild assets_by_role whenever views change
+    try {
+      await this.computeAssetsByRole();
+    } catch (error) {
+      console.error("Error cpmputing assets byy role", error);
     }
     if (!noSignal) this.log(5, "Refresh views");
 

--- a/packages/saltcorn-types/base_types.ts
+++ b/packages/saltcorn-types/base_types.ts
@@ -60,6 +60,8 @@ export type Header = {
   script?: string;
   css?: string;
   headerTag?: string;
+  onlyViews?: string[];
+  onlyFieldviews?: string[];
 };
 
 type MenuItem = {

--- a/packages/server/wrapper.js
+++ b/packages/server/wrapper.js
@@ -122,9 +122,16 @@ const get_headers = (req, version_tag, description, extras = []) => {
   if (state.getConfig("log_client_errors", false))
     from_cfg.push({ scriptBody: `enable_error_catcher()` });
   const state_headers = [];
-  for (const hs of Object.values(state.headers)) {
-    state_headers.push(...hs);
+  const assets_by_role = state.assets_by_role || {};
+  const roleHeaders = assets_by_role[req.user?.role_id || 100];
+  if (roleHeaders && roleHeaders.length) {
+    state_headers.push(...roleHeaders);
+  } else {
+    for (const hs of Object.values(state.headers)) {
+      state_headers.push(...hs);
+    }
   }
+
   if (notification_in_menu)
     from_cfg.push({ scriptBody: domReady(`check_saltcorn_notifications()`) });
   if (pwa_enabled) {


### PR DESCRIPTION
### Summary
1. Compute and store state.assets_by_role so wrapper can send only the headers required for the current user's role.
2. Headers emitted by plugins may include onlyViews to indicate they are only needed by views that use a particular view template/name. When present, the header will only be included for roles that can access at least one matching view.


### Notes / TODO
- onlyFieldviews is only defined in types for now.