### PR TITLE
including dist directory over npmignore

### DIFF
--- a/packages/plain-date/package.json
+++ b/packages/plain-date/package.json
@@ -48,5 +48,8 @@
   "types": "index.d.ts",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist/**/*"
+  ]
 }


### PR DESCRIPTION
### Summary
Including necessary build files in plain-date package.json