### PR TITLE
Fix ToggleFilter input class from 'w-100' to 'form-control'

### DIFF
--- a/packages/saltcorn-builder/src/components/elements/ToggleFilter.js
+++ b/packages/saltcorn-builder/src/components/elements/ToggleFilter.js
@@ -131,7 +131,7 @@ const ToggleFilterSettings = () => {
             ) : (
               <input
                 value={value}
-                className="w-100"
+                className="form-control"
                 onChange={setAProp("value")}
               />
             )}
@@ -165,7 +165,7 @@ const ToggleFilterSettings = () => {
           <td>
             <input
               value={label}
-              className="w-100"
+              className="form-control"
               onChange={setAProp("label")}
             />
           </td>


### PR DESCRIPTION
Change class of input to the correct `form-control` class to match the styling of all other saltcorn builder components.

It currently looks like this
<img width="266" height="377" alt="image" src="https://github.com/user-attachments/assets/a53e7690-d360-46be-8d02-345d6dc426dd" />

After the fix it looks like this
<img width="265" height="434" alt="image" src="https://github.com/user-attachments/assets/59dbfa52-19fc-4cbd-acd8-5cb032d93231" />