### PR TITLE
fix: use default import for useTranslation hook

### DIFF
--- a/packages/saltcorn-builder/src/components/elements/RelationOnDemandPicker.js
+++ b/packages/saltcorn-builder/src/components/elements/RelationOnDemandPicker.js
@@ -3,7 +3,7 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { removeWhitespaces, rand_ident } from "./utils";
-import { useTranslation } from "../../hooks/useTranslation";
+import useTranslation from "../../hooks/useTranslation";
 
 const maxLevelDefault = 10;
 const renderInto = (container, node) => {


### PR DESCRIPTION
The useTranslation hook uses a default export but was imported as a named export, causing TypeError in tests.