### PR TITLE
protect api with csrf token when using cookie auth

### DIFF
--- a/infosec-scan/py-sectest/dynamic_updates_client.py
+++ b/infosec-scan/py-sectest/dynamic_updates_client.py
@@ -29,12 +29,13 @@ class DynamicUpdatesClient:
     self.csrf = self.session.csrf()
 
   def login(self, email, password):
-    self.session.postForm('/auth/login', 
-      {'email': email, 
-        'password': password, 
+    self.session.postForm('/auth/login',
+      {'email': email,
+        'password': password,
         '_csrf': self.csrf
       })
     assert self.session.redirect_url == '/'
+    self.session.get('/')  # refresh CSRF for the new post-login session
 
   def connect(self):
     auth_headers = 'connect.sid=' + self.session.sessionID() + '; loggedin=true'

--- a/infosec-scan/py-sectest/real_time_collab_client.py
+++ b/infosec-scan/py-sectest/real_time_collab_client.py
@@ -27,12 +27,13 @@ class RealTimeCollabClient:
     self.csrf = self.session.csrf()
 
   def login(self, email, password):
-    self.session.postForm('/auth/login', 
-        {'email': email, 
-          'password': password, 
+    self.session.postForm('/auth/login',
+        {'email': email,
+          'password': password,
           '_csrf': self.csrf
         })
     assert self.session.redirect_url == '/'
+    self.session.get('/')  # refresh CSRF for the new post-login session
 
   def connect(self):
     auth_headers = 'connect.sid=' + self.session.sessionID() + '; loggedin=true'

--- a/infosec-scan/py-sectest/scsession.py
+++ b/infosec-scan/py-sectest/scsession.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 class SaltcornSession(Session):
   def __init__(self, port=3001, open_process=True, env_vars=None, pipe_output=False):
     self.salcorn_process = None
+    self._last_csrf = ''
     self.open(port, open_process, env_vars, pipe_output)
 
   def __del__(self):
@@ -28,6 +29,16 @@ class SaltcornSession(Session):
       return m[0]
     else:
       return ""
+
+  def get(self, url, allow_redirects=False, timeout=30):
+    super().get(url, allow_redirects=allow_redirects, timeout=timeout)
+    token = self.csrf()
+    if token:
+      self._last_csrf = token
+
+  def apiPost(self, url, data, allow_redirects=False, extra_headers=None):
+    super().apiPost(url, data, allow_redirects=allow_redirects,
+                    extra_headers=extra_headers, csrf_token=self._last_csrf or None)
 
   def close(self):
     if self.salcorn_process is not None:

--- a/infosec-scan/py-sectest/sectest.py
+++ b/infosec-scan/py-sectest/sectest.py
@@ -31,8 +31,10 @@ class Session:
     resp = self.session.post(urljoin(self.base_url, url), data=data, allow_redirects=allow_redirects)
     self.__read_response(resp)
 
-  def apiPost(self, url, data, allow_redirects=False, extra_headers=None):
+  def apiPost(self, url, data, allow_redirects=False, extra_headers=None, csrf_token=None):
     headers = {'Content-Type': 'application/json', **(extra_headers or {})}
+    if csrf_token:
+      headers['x-csrf-token'] = csrf_token
     resp = self.session.post(urljoin(self.base_url, url), json=data, headers=headers, allow_redirects=allow_redirects)
     self.__read_response(resp)
 

--- a/packages/server/app.js
+++ b/packages/server/app.js
@@ -67,6 +67,7 @@ const jwtOpts = {
   secretOrKey: jwt_secret,
   issuer: "saltcorn@saltcorn",
   audience: "saltcorn-mobile-app",
+  passReqToCallback: true,
 };
 
 const disabledCsurf = (req, res, next) => {
@@ -361,9 +362,10 @@ const getApp = async (opts = {}) => {
     })
   );
   passport.use(
-    new JwtStrategy(jwtOpts, async (jwt_payload, done) => {
+    new JwtStrategy(jwtOpts, async (req, jwt_payload, done) => {
       const userCheck = async () => {
         if (jwt_payload.sub === "public") {
+          req.jwtAuthenticated = true;
           return done(null, { role_id: 100 });
         }
         const u = await User.findOne({ email: jwt_payload.sub });
@@ -376,6 +378,7 @@ const getApp = async (opts = {}) => {
             ? new Date(u.last_mobile_login).valueOf()
             : u.last_mobile_login) <= jwt_payload.iat
         ) {
+          req.jwtAuthenticated = true;
           return done(null, u.session_object);
         } else {
           return done(null, false);
@@ -424,9 +427,6 @@ const getApp = async (opts = {}) => {
 
   app.use(wrapper(version_tag));
 
-  app.use("/api", api);
-  app.use("/scapi", scapi);
-
   const pluginRoutesHandler = new PluginRoutesHandler();
   await eachTenant(async () => {
     pluginRoutesHandler.initTenantRouter(
@@ -455,7 +455,8 @@ const getApp = async (opts = {}) => {
           (req.url.startsWith("/api/") ||
             req.url === "/auth/login-with/jwt" ||
             req.url === "/auth/signup")) ||
-        jwt_extractor(req) ||
+        req.jwtAuthenticated ||
+        req.headers.authorization?.toLowerCase().startsWith("bearer ") ||
         req.url === "/auth/callback/saml" ||
         req.url.startsWith("/notifications/share-handler") ||
         req.url.startsWith("/notifications/manifest")
@@ -464,6 +465,9 @@ const getApp = async (opts = {}) => {
       csurf(req, res, next);
     });
   } else app.use(disabledCsurf);
+
+  app.use("/api", api);
+  app.use("/scapi", scapi);
 
   mountRoutes(app);
   // set tenant homepage as / root

--- a/packages/server/tests/api.test.js
+++ b/packages/server/tests/api.test.js
@@ -822,7 +822,10 @@ describe("API emit-event access control", () => {
         .set("Authorization", `jwt ${adminJwt}`)
         .send({ payload: {} })
         .expect(
-          respondJsonWith(403, (resp) => resp.error === "Event type not allowed")
+          respondJsonWith(
+            403,
+            (resp) => resp.error === "Event type not allowed"
+          )
         );
     }
   });
@@ -1223,5 +1226,57 @@ describe("API cross-table sub-select access control", () => {
     const rows1 = resp1.body.success || [];
     const rows2 = resp2.body.success || [];
     expect(rows1.length).toBe(rows2.length);
+  });
+});
+
+describe("API CSRF protection", () => {
+  let adminToken, adminJwt;
+
+  beforeAll(async () => {
+    const admin = await User.findOne({ email: "admin@foo.com" });
+    adminToken = await admin.getNewAPIToken();
+    adminJwt = await getAdminJwt();
+  });
+
+  it("should reject POST with session cookie but no CSRF token", async () => {
+    const app = await getApp({ disableCsrf: false });
+    const loginCookie = await getAdminLoginCookie();
+    await request(app)
+      .post("/api/books/")
+      .set("Cookie", loginCookie)
+      .send({ author: "CSRF Test", pages: 1 })
+      .set("Content-Type", "application/json")
+      .expect(302);
+  });
+
+  it("should allow POST with bearer token and no CSRF token", async () => {
+    const app = await getApp({ disableCsrf: false });
+    await request(app)
+      .post("/api/books/")
+      .set("Authorization", "Bearer " + adminToken)
+      .send({ author: "Bearer No CSRF", pages: 2 })
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json")
+      .expect(succeedJsonWith((resp) => resp && typeof resp === "number"));
+  });
+
+  it("should allow POST with valid JWT and no CSRF token", async () => {
+    const app = await getApp({ disableCsrf: false });
+    await request(app)
+      .post("/api/books/")
+      .set("Authorization", `jwt ${adminJwt}`)
+      .send({ author: "JWT No CSRF", pages: 3 })
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json")
+      .expect(succeedJsonWith((resp) => resp && typeof resp === "number"));
+  });
+
+  it("should not bypass CSRF by appending a fake ?jwt= query parameter", async () => {
+    const app = await getApp({ disableCsrf: false });
+    await request(app)
+      .post("/api/books/?jwt=fakejwt")
+      .send({ author: "CSRF Bypass Attempt", pages: 4 })
+      .set("Content-Type", "application/json")
+      .expect(302);
   });
 });


### PR DESCRIPTION
### Apply CSRF checks to /api, if authenticating with a session cookie (but not with jwt or api token) #4083