### PR TITLE
Check if we have a modal ancestor before setting SaltcornModalRequest…

### DIFF
--- a/packages/server/public/saltcorn.js
+++ b/packages/server/public/saltcorn.js
@@ -762,12 +762,13 @@ function ajaxSubmitForm(e, force_no_reload, event) {
   var form = $(e).closest("form");
   var url = form.attr("action");
   if (event) event.preventDefault();
+  var inModal = form.closest("#scmodal").length > 0;
   $.ajax(url, {
     type: "POST",
     headers: {
       "CSRF-Token": _sc_globalCsrf,
       "Page-Load-Tag": _sc_pageloadtag,
-      SaltcornModalRequest: "true",
+      ...(inModal ? { SaltcornModalRequest: "true" } : {}),
     },
     data: new FormData(form[0]),
     processData: false,


### PR DESCRIPTION
… in ajaxSubmitForm

### Validation errors in Edit view opening in nested modal instead of existing modal #4123