### PR TITLE
Add Cache-Control no-store to full-page sendWrap responses

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,8 +6,8 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.735.0",
-    "@aws-sdk/s3-request-presigner": "^3.940.0",
+    "@aws-sdk/client-s3": "3.1040.0",
+    "@aws-sdk/s3-request-presigner": "3.1040.0",
     "@dr.pogodin/csurf": "1.15.0",
     "@saltcorn/admin-models": "1.6.0-beta.13",
     "@saltcorn/base-plugin": "1.6.0-beta.13",

--- a/packages/server/wrapper.js
+++ b/packages/server/wrapper.js
@@ -343,6 +343,10 @@ module.exports = (version_tag) =>
             ]
           : [];
 
+      res.header(
+        "Cache-Control",
+        "private, no-cache, no-store, must-revalidate"
+      );
       res.send(
         layout.wrap({
           title,


### PR DESCRIPTION
Saltcorn overwrites builder and other auto-save content when opening a cached page or going back in browser history
 #4179