### PR TITLE
add help_text tooltip to Edit view form fields

### DIFF
--- a/packages/saltcorn-builder/src/components/elements/Field.js
+++ b/packages/saltcorn-builder/src/components/elements/Field.js
@@ -100,6 +100,7 @@ const FieldSettings = () => {
     click_to_edit,
     textStyle,
     onchange_action,
+    help_text,
   } = useNode((node) => ({
     name: node.data.props.name,
     fieldview: node.data.props.fieldview,
@@ -109,6 +110,7 @@ const FieldSettings = () => {
     textStyle: node.data.props.textStyle,
     onchange_action: node.data.props.onchange_action,
     configuration: node.data.props.configuration,
+    help_text: node.data.props.help_text,
     node_id: node.id,
   }));
   const options = useContext(optionsCtx);
@@ -277,6 +279,24 @@ const FieldSettings = () => {
           onChange={(k, v) => refetchPreview({ configuration: { [k]: v } })}
         />
       ) : null}
+      {options.mode === "edit" ? (
+        <Fragment>
+          <label>{t("Help text")}</label>
+          <textarea
+            className="form-control"
+            rows={2}
+            placeholder={t("Tooltip shown next to field label")}
+            value={help_text || ""}
+            onChange={(e) => {
+              if (!e.target) return;
+              const value = e.target.value;
+              setProp((prop) => {
+                prop.help_text = value;
+              });
+            }}
+          />
+        </Fragment>
+      ) : null}
       {options.mode === "edit" && options.triggerActions ? (
         <Fragment>
           <label>{t("On change action")}</label>
@@ -330,6 +350,7 @@ Field.craft = {
       "inline",
       "click_to_edit",
       "onchange_action",
+      "help_text",
       { name: "configuration", default: {} },
     ],
   },

--- a/packages/saltcorn-builder/src/components/elements/Field.js
+++ b/packages/saltcorn-builder/src/components/elements/Field.js
@@ -101,6 +101,7 @@ const FieldSettings = () => {
     textStyle,
     onchange_action,
     help_text,
+    help_text_position,
   } = useNode((node) => ({
     name: node.data.props.name,
     fieldview: node.data.props.fieldview,
@@ -111,6 +112,7 @@ const FieldSettings = () => {
     onchange_action: node.data.props.onchange_action,
     configuration: node.data.props.configuration,
     help_text: node.data.props.help_text,
+    help_text_position: node.data.props.help_text_position,
     node_id: node.id,
   }));
   const options = useContext(optionsCtx);
@@ -295,6 +297,25 @@ const FieldSettings = () => {
               });
             }}
           />
+          {help_text ? (
+            <Fragment>
+              <label className="mt-1">{t("Help text position")}</label>
+              <select
+                value={help_text_position || "after-label"}
+                className="form-control form-select"
+                onChange={(e) => {
+                  if (!e.target) return;
+                  const value = e.target.value;
+                  setProp((prop) => {
+                    prop.help_text_position = value;
+                  });
+                }}
+              >
+                <option value="after-label">{t("After label")}</option>
+                <option value="inside-input">{t("Inside input (right)")}</option>
+              </select>
+            </Fragment>
+          ) : null}
         </Fragment>
       ) : null}
       {options.mode === "edit" && options.triggerActions ? (
@@ -351,6 +372,7 @@ Field.craft = {
       "click_to_edit",
       "onchange_action",
       "help_text",
+      "help_text_position",
       { name: "configuration", default: {} },
     ],
   },

--- a/packages/saltcorn-data/models/field.ts
+++ b/packages/saltcorn-data/models/field.ts
@@ -84,6 +84,7 @@ class Field implements AbstractField {
   default?: string;
   sublabel?: string;
   description?: string;
+  help_text?: string;
   type?: string | Type;
   typename?: string;
   help?: { topic: string; context?: Row; dynContext?: string[] };
@@ -135,6 +136,7 @@ class Field implements AbstractField {
     this.default = o.default;
     this.sublabel = o.sublabel;
     this.description = o.description;
+    this.help_text = o.help_text;
     const { getState } = require("../db/state");
 
     this.type = typeof o.type === "string" ? getState().types[o.type] : o.type;
@@ -226,6 +228,7 @@ class Field implements AbstractField {
       reftype: this.reftype,
       refname: this.refname,
       description: this.description,
+      help_text: this.help_text,
     };
   }
 

--- a/packages/saltcorn-data/viewable_fields.ts
+++ b/packages/saltcorn-data/viewable_fields.ts
@@ -2160,6 +2160,7 @@ const getForm = async (
             typeof f.attributes.block === "undefined"
           )
             f.attributes.block = column.block;
+          if (column.help_text) f.help_text = column.help_text;
           return f;
         } else if (table.name === "users" && column.field_name === "password") {
           return new Field({

--- a/packages/saltcorn-data/viewable_fields.ts
+++ b/packages/saltcorn-data/viewable_fields.ts
@@ -2161,6 +2161,8 @@ const getForm = async (
           )
             f.attributes.block = column.block;
           if (column.help_text) f.help_text = column.help_text;
+          if (column.help_text_position)
+            f.help_text_position = column.help_text_position;
           return f;
         } else if (table.name === "users" && column.field_name === "password") {
           return new Field({

--- a/packages/saltcorn-markup/form.ts
+++ b/packages/saltcorn-markup/form.ts
@@ -106,8 +106,15 @@ const formRowWrap = (
   error: string = "",
   fStyle: string,
   labelCols: number
-): string =>
-  div(
+): string => {
+  const insideInput =
+    hdr.help_text && hdr.help_text_position === "inside-input";
+  const resolvedInner = insideInput
+    ? helpTextInputGroup(inner, hdr.help_text)
+    : inner;
+  const labelIcon =
+    hdr.help_text && !insideInput ? helpTextIcon(hdr.help_text) : "";
+  return div(
     {
       class: [
         "form-group",
@@ -129,16 +136,15 @@ const formRowWrap = (
           },
           h5(text(hdr.label)),
           hdr.help && !hdr.sublabel ? helpLink(hdr.help) : "",
-          hdr.help_text ? helpTextIcon(hdr.help_text) : "",
-          //hdr.sublabel && p(i(hdr.sublabel)),
+          labelIcon,
           mkSubLabelAndHelp(hdr)
         )
       : hdr.input_type === "dynamic_fields"
-        ? inner
+        ? resolvedInner
         : hdr.type?.name === "Bool" && fStyle === "vert"
           ? div(
               { class: "form-check" },
-              inner,
+              resolvedInner,
               label(
                 {
                   for: `input${text_attr(hdr.form_name)}`,
@@ -146,7 +152,7 @@ const formRowWrap = (
                 text(hdr.label)
               ),
               hdr.help && !hdr.sublabel ? helpLink(hdr.help) : "",
-              hdr.help_text ? helpTextIcon(hdr.help_text) : ""
+              labelIcon
             ) + mkSubLabelAndHelp(hdr)
           : [
               hdr.label !== " " &&
@@ -171,7 +177,7 @@ const formRowWrap = (
                     text(hdr.label)
                   ),
                   hdr.help && !hdr.sublabel ? helpLink(hdr.help) : "",
-                  hdr.help_text ? helpTextIcon(hdr.help_text) : ""
+                  labelIcon
                 ),
               div(
                 {
@@ -184,12 +190,13 @@ const formRowWrap = (
                       `col-sm-${12 - labelCols}`,
                   ],
                 },
-                inner,
+                resolvedInner,
                 text(error),
                 mkSubLabelAndHelp(hdr)
               ),
             ]
   );
+};
 
 /**
  * builds dropdown submenus to select a field,
@@ -1185,6 +1192,22 @@ const helpTextIcon = (help_text: string) =>
     title: text_attr(help_text),
   });
 
+const helpTextInputGroup = (inner: string, help_text: string) =>
+  div(
+    { class: "input-group" },
+    inner,
+    span(
+      {
+        class: "input-group-text",
+        "data-bs-toggle": "tooltip",
+        "data-bs-placement": "left",
+        title: text_attr(help_text),
+        style: "cursor:default",
+      },
+      i({ class: "fas fa-info-circle text-muted" })
+    )
+  );
+
 const mkSubLabelAndHelp = (hdr: any) => {
   return (
     (hdr.sublabel ? i(hdr.sublabel) : "") +
@@ -1211,8 +1234,12 @@ const mkFormRowAside = (
 ): string => {
   const name: any = hdr1.form_name + nameAdd;
 
-  const inner1 = innerField(v, errors, nameAdd, "")(hdr1);
-  const inner2 = innerField(v, errors, nameAdd, "")(hdr2);
+  const resolveInner = (hdr: any, raw: string) =>
+    hdr.help_text && hdr.help_text_position === "inside-input"
+      ? helpTextInputGroup(raw, hdr.help_text)
+      : raw;
+  const inner1 = resolveInner(hdr1, innerField(v, errors, nameAdd, "")(hdr1));
+  const inner2 = resolveInner(hdr2, innerField(v, errors, nameAdd, "")(hdr2));
   const inputCols = (12 - labelCols * 2) / 2;
   const mkLabel = (hdr: any) =>
     label(
@@ -1221,7 +1248,9 @@ const mkFormRowAside = (
       },
       text(hdr.label),
       hdr.help && !hdr.sublabel ? helpLink(hdr.help) : "",
-      hdr.help_text ? helpTextIcon(hdr.help_text) : ""
+      hdr.help_text && hdr.help_text_position !== "inside-input"
+        ? helpTextIcon(hdr.help_text)
+        : ""
     );
   const outerAttributes = {
     class: ["form-group row"],

--- a/packages/saltcorn-markup/form.ts
+++ b/packages/saltcorn-markup/form.ts
@@ -129,6 +129,7 @@ const formRowWrap = (
           },
           h5(text(hdr.label)),
           hdr.help && !hdr.sublabel ? helpLink(hdr.help) : "",
+          hdr.help_text ? helpTextIcon(hdr.help_text) : "",
           //hdr.sublabel && p(i(hdr.sublabel)),
           mkSubLabelAndHelp(hdr)
         )
@@ -144,7 +145,8 @@ const formRowWrap = (
                 },
                 text(hdr.label)
               ),
-              hdr.help && !hdr.sublabel ? helpLink(hdr.help) : ""
+              hdr.help && !hdr.sublabel ? helpLink(hdr.help) : "",
+              hdr.help_text ? helpTextIcon(hdr.help_text) : ""
             ) + mkSubLabelAndHelp(hdr)
           : [
               hdr.label !== " " &&
@@ -168,7 +170,8 @@ const formRowWrap = (
                     },
                     text(hdr.label)
                   ),
-                  hdr.help && !hdr.sublabel ? helpLink(hdr.help) : ""
+                  hdr.help && !hdr.sublabel ? helpLink(hdr.help) : "",
+                  hdr.help_text ? helpTextIcon(hdr.help_text) : ""
                 ),
               div(
                 {
@@ -1174,11 +1177,18 @@ const helpLink = ({ topic, context, dynContext, plugin }: any) => {
     i({ class: "fas fa-question-circle ms-1" })
   );
 };
+const helpTextIcon = (help_text: string) =>
+  i({
+    class: "fas fa-info-circle ms-1 text-muted",
+    "data-bs-toggle": "tooltip",
+    "data-bs-placement": "right",
+    title: text_attr(help_text),
+  });
+
 const mkSubLabelAndHelp = (hdr: any) => {
   return (
     (hdr.sublabel ? i(hdr.sublabel) : "") +
     (hdr.help && hdr.sublabel ? helpLink(hdr.help) : "")
-    //(hdr.help && !hdr.sublabel ? "Help" + helpLink(hdr.help) : "")
   );
 };
 
@@ -1210,7 +1220,8 @@ const mkFormRowAside = (
         for: `input${text_attr(hdr.form_name)}`,
       },
       text(hdr.label),
-      hdr.help && !hdr.sublabel ? helpLink(hdr.help) : ""
+      hdr.help && !hdr.sublabel ? helpLink(hdr.help) : "",
+      hdr.help_text ? helpTextIcon(hdr.help_text) : ""
     );
   const outerAttributes = {
     class: ["form-group row"],
@@ -1282,6 +1293,18 @@ const renderFormLayout = (form: Form): string => {
           )
         )
         .join("");
+    },
+    blank(segment: any) {
+      if (!segment.labelFor) return false;
+      const matchingField = form.fields.find(
+        (f) => f.name === segment.labelFor && (f as any).help_text
+      );
+      if (!matchingField) return false;
+      return label(
+        { for: `input${text_attr(segment.labelFor)}` },
+        text(segment.contents || ""),
+        helpTextIcon((matchingField as any).help_text)
+      );
     },
     field_repeat({ field_repeat }: any, go: any) {
       const hdr = field_repeat;

--- a/packages/saltcorn-markup/help_text.test.ts
+++ b/packages/saltcorn-markup/help_text.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for the field help_text / tooltip feature.
+ *
+ * Uses mkFormContentNoLayout and mkForm directly so we can pass plain
+ * field objects without importing AbstractForm (which has a broken type
+ * path in the standalone package install).
+ */
+import { describe, it, expect } from "@jest/globals";
+import index from "./index";
+const { mkFormContentNoLayout, mkForm } = index;
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+/** Collapse all whitespace / newlines so HTML comparisons aren't fragile. */
+const flat = (s: string) => s.replace(/\s+/g, " ").trim();
+
+/** A minimal form field with no help_text. */
+const baseField = (overrides: Record<string, any> = {}) => ({
+  name: "email",
+  label: "Email",
+  input_type: "text" as const,
+  form_name: "email",
+  required: false,
+  attributes: {},
+  is_fkey: false,
+  ...overrides,
+});
+
+/** A minimal form shape accepted by mkForm / mkFormContentNoLayout. */
+const baseForm = (fields: any[], overrides: Record<string, any> = {}) => ({
+  action: "/",
+  fields,
+  errors: {},
+  values: {},
+  formStyle: "vert",
+  methodGET: false,
+  xhrSubmit: false,
+  req: {},
+  viewname: "testform",
+  ...overrides,
+});
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+describe("help_text tooltip icon", () => {
+  it("is NOT rendered when help_text is absent", () => {
+    const form = baseForm([baseField()]);
+    const html = mkFormContentNoLayout(form);
+    expect(html).not.toContain("fa-info-circle");
+    expect(html).not.toContain("data-bs-toggle");
+  });
+
+  it("is NOT rendered when help_text is an empty string", () => {
+    const form = baseForm([baseField({ help_text: "" })]);
+    const html = mkFormContentNoLayout(form);
+    expect(html).not.toContain("fa-info-circle");
+  });
+
+  it("renders a tooltip icon when help_text is set", () => {
+    const form = baseForm([baseField({ help_text: "Enter your email address" })]);
+    const html = mkFormContentNoLayout(form);
+    expect(html).toContain("fa-info-circle");
+    expect(html).toContain('data-bs-toggle="tooltip"');
+  });
+
+  it("puts the help_text value in the title attribute", () => {
+    const form = baseForm([
+      baseField({ help_text: "Enter your email address" }),
+    ]);
+    const html = mkFormContentNoLayout(form);
+    expect(html).toContain('title="Enter your email address"');
+  });
+
+  it("HTML-escapes special characters in help_text", () => {
+    const form = baseForm([
+      baseField({ help_text: 'Use format "user@example.com"' }),
+    ]);
+    const html = mkFormContentNoLayout(form);
+    // text_attr escapes double quotes to &#34; or &quot;
+    expect(html).not.toContain('title="Use format "user@example.com""');
+    expect(html).toContain("title=");
+    // The escaped version must appear (exact entity depends on text_attr impl)
+    expect(flat(html)).toMatch(/title="Use format (&quot;|&#34;|\\")user@example\.com/);
+  });
+
+  it("places the icon inside the label div (next to the label text)", () => {
+    const form = baseForm([
+      baseField({ help_text: "Tooltip content here" }),
+    ]);
+    const html = mkFormContentNoLayout(form);
+    // The label div should contain both the label text AND the icon
+    const labelDivMatch = html.match(
+      /<div[^>]*>[\s\S]*?<label[^>]*>Email<\/label>[\s\S]*?fa-info-circle[\s\S]*?<\/div>/
+    );
+    expect(labelDivMatch).not.toBeNull();
+  });
+
+  it("icon appears for a Bool field (checkbox) which uses a different render path", () => {
+    const form = baseForm([
+      {
+        ...baseField(),
+        name: "active",
+        label: "Active",
+        form_name: "active",
+        input_type: "checkbox" as const,
+        type: { name: "Bool" },
+        help_text: "Whether this record is active",
+      },
+    ]);
+    const html = mkFormContentNoLayout(form);
+    expect(html).toContain("fa-info-circle");
+    expect(html).toContain('title="Whether this record is active"');
+  });
+
+  it("does not affect fields without help_text in a multi-field form", () => {
+    const form = baseForm([
+      baseField({ name: "email", form_name: "email", label: "Email", help_text: "Your email" }),
+      baseField({ name: "name",  form_name: "name",  label: "Name"  }), // no help_text
+    ]);
+    const html = mkFormContentNoLayout(form);
+    // Exactly one tooltip icon — for the email field only
+    const iconMatches = html.match(/fa-info-circle/g) || [];
+    expect(iconMatches.length).toBe(1);
+    expect(html).toContain('title="Your email"');
+  });
+
+  it("renders correctly via mkForm (full form wrapper)", () => {
+    const form = baseForm([
+      baseField({ help_text: "Full form test" }),
+    ]);
+    const html = mkForm(form, "csrf123");
+    expect(html).toContain("fa-info-circle");
+    expect(html).toContain('title="Full form test"');
+    expect(html).toContain('data-bs-placement="right"');
+  });
+});

--- a/packages/saltcorn-markup/help_text.test.ts
+++ b/packages/saltcorn-markup/help_text.test.ts
@@ -134,3 +134,37 @@ describe("help_text tooltip icon", () => {
     expect(html).toContain('data-bs-placement="right"');
   });
 });
+
+describe("help_text_position inside-input", () => {
+  it("wraps the input in an input-group when position is inside-input", () => {
+    const form = baseForm([
+      baseField({ help_text: "Format: YYYY-MM-DD", help_text_position: "inside-input" }),
+    ]);
+    const html = mkFormContentNoLayout(form);
+    expect(flat(html)).toContain('class="input-group"');
+    expect(html).toContain("fa-info-circle");
+    expect(html).toContain('title="Format: YYYY-MM-DD"');
+  });
+
+  it("does NOT place the icon next to the label when position is inside-input", () => {
+    const form = baseForm([
+      baseField({ help_text: "Format: YYYY-MM-DD", help_text_position: "inside-input" }),
+    ]);
+    const html = mkFormContentNoLayout(form);
+    // Icon must NOT appear inside the label element
+    const labelMatch = html.match(/<label[^>]*>[\s\S]*?<\/label>/);
+    expect(labelMatch).not.toBeNull();
+    expect(labelMatch![0]).not.toContain("fa-info-circle");
+  });
+
+  it("defaults to after-label behaviour when position is omitted", () => {
+    const form = baseForm([
+      baseField({ help_text: "After label" }),
+    ]);
+    const html = mkFormContentNoLayout(form);
+    // No input-group wrapper
+    expect(flat(html)).not.toContain('class="input-group"');
+    // Icon still present
+    expect(html).toContain("fa-info-circle");
+  });
+});

--- a/packages/saltcorn-types/model-abstracts/abstract_field.ts
+++ b/packages/saltcorn-types/model-abstracts/abstract_field.ts
@@ -40,6 +40,7 @@ export type FieldCfg = {
   sublabel?: string;
   help?: { topic: string; context?: Row; dynContext?: string[] };
   description?: string;
+  help_text?: string;
   type?: string | Type;
   options?: Array<string | { label: string; value: string }>;
   required?: boolean;


### PR DESCRIPTION
Adds an optional `help_text` property to field segments in Edit views. When set, an info icon is rendered as a Bootstrap tooltip so users can surface field-level guidance without cluttering the form.

## Changes

**`packages/saltcorn-markup/form.ts`**
- `helpTextIcon()` — renders `<i class="fas fa-info-circle">` with `data-bs-toggle="tooltip"`
- `helpTextInputGroup()` — wraps the input in a Bootstrap `input-group` with the icon appended as `input-group-text` on the right
- `formRowWrap` and `mkFormRowAside` resolve `help_text_position` before rendering:
  - `"after-label"` (default) — icon placed next to the label text
  - `"inside-input"` — icon embedded inside the input field on the right

**`packages/saltcorn-builder/src/components/elements/Field.js`**
- Adds a **Help text** textarea in FieldSettings (Edit mode only)
- When help text is filled, a **Help text position** dropdown appears with options: `After label` / `Inside input (right)`

**`packages/saltcorn-data/viewable_fields.ts`**
- Forwards `help_text` and `help_text_position` from column config to the field header

**`packages/saltcorn-markup/help_text.test.ts`**
- 10 tests covering: no icon when absent, icon when set, title escaping, label placement, Bool field path, multi-field form, `inside-input` wrapping, label-icon suppression for inside-input, and default fallback

<img width="1314" height="346" alt="Screenshot 2026-06-10 at 1 47 39 PM" src="https://github.com/user-attachments/assets/7dc252c6-60c9-4a45-8228-06ed76438061" />
<img width="1230" height="723" alt="Screenshot 2026-06-10 at 1 47 50 PM" src="https://github.com/user-attachments/assets/c689fc01-9dae-4ee3-b94d-8afc0013eade" />