### PR TITLE
#4059: underline header for calculated non-stored fields in List view

### DIFF
--- a/packages/saltcorn-data/viewable_fields.ts
+++ b/packages/saltcorn-data/viewable_fields.ts
@@ -1422,6 +1422,7 @@ const get_viewable_fields = (
               !f.calculated || f.stored
                 ? sortlinkForName(f.name, req, viewname, statehash)
                 : undefined,
+            header_underline: f.calculated && !f.stored ? true : undefined,
           };
         if (column.click_to_edit) {
           const updateKey = (fvr: any, column_key?: any) => {

--- a/packages/saltcorn-markup/table.ts
+++ b/packages/saltcorn-markup/table.ts
@@ -55,7 +55,9 @@ const headerCell = (hdr: any, opts: any, ix: number): string => {
     },
     hdr.sortlink
       ? span({ onclick: hdr.sortlink, class: "link-style" }, hdr.label)
-      : hdr.label,
+      : hdr.header_underline
+        ? span({ style: "text-decoration: underline" }, hdr.label)
+        : hdr.label,
     opts.header_filters_dropdown &&
       hdr.header_filter &&
       span(
@@ -126,7 +128,9 @@ const headerCellWithToggle = (
     return headerCell(hdr, opts, ix);
   const content = hdr.sortlink
     ? span({ onclick: hdr.sortlink, class: "link-style" }, hdr.label)
-    : hdr.label;
+    : hdr.header_underline
+      ? span({ style: "text-decoration: underline" }, hdr.label)
+      : hdr.label;
   const toggleIcon = span(
     {
       class: "header-filter-toggle link-style float-end",


### PR DESCRIPTION
## Problem
Calculated (non-stored) field column headers in List views rendered as plain
text with no underline, while all other column headers had an underline. The
visual inconsistency was reported in versions 1.5.0–1.5.5.

## Root cause
`viewable_fields.ts` intentionally sets `sortlink: undefined` for calculated
non-stored fields (they cannot be sorted server-side). `headerCell` and
`headerCellWithToggle` in `table.ts` only wrap the label in `span.link-style`
(which carries `text-decoration: underline`) when `sortlink` is present — so
these headers silently lost their underline.

## Changes
- `viewable_fields.ts` — sets `header_underline: true` for `f.calculated && !f.stored` fields
- `table.ts` — `headerCell` and `headerCellWithToggle` now check `hdr.header_underline`
  and render `<span style="text-decoration: underline">` when set, preserving the
  visual styling without adding `cursor: pointer` or an `onclick` (correct UX —
  the column is still non-sortable)