### PR TITLE
fix: scroll elements into view before drag-and-drop in Playwright helper

### DIFF
--- a/deploy/playwright/pageobject/function.js
+++ b/deploy/playwright/pageobject/function.js
@@ -31,6 +31,8 @@ class PageFunctions {
 
 
   async drag_And_Drop(source, target) {
+    await this.page.locator(source).scrollIntoViewIfNeeded();
+    await this.page.locator(target).scrollIntoViewIfNeeded();
     await this.page.locator(source).dragTo(this.page.locator(target), { force: true });
   }
 


### PR DESCRIPTION
Fixes flaky TC_13_Feed "Create view with show view pattern" test which fails in CI
with "Element is outside of the viewport" on drag-and-drop operations.

## Root cause
`drag_And_Drop` in `function.js` passed `{ force: true }` to `dragTo`, which
bypasses actionability checks on the source but does not scroll the target into
the visible viewport. In CI's headless browser the page builder canvas is taller
than the viewport, so the Address element was unreachable.

## Fix
Call `scrollIntoViewIfNeeded()` on both the source and target locators before
dragging. This ensures both elements are in the viewport regardless of
window/canvas height in CI.
