### PR TITLE
add conditional cell CSS formatting to List view columns

### DIFF
--- a/packages/saltcorn-builder/src/components/elements/ListColumn.js
+++ b/packages/saltcorn-builder/src/components/elements/ListColumn.js
@@ -161,6 +161,15 @@ const fields = [
     input_type: "select",
     options: ["Default", "Left", "Center", "Right"],
   },
+  {
+    name: "cell_css_formula",
+    label: "Cell CSS formula",
+    sublabel:
+      "Bootstrap class or inline style expression based on row value. Ex: amount < 0 ? 'text-danger fw-bold' : null",
+    class: "validate-expression",
+    type: "String",
+    required: false,
+  },
 ];
 ListColumn.craft = {
   displayName: "ListColumn",

--- a/packages/saltcorn-data/tests/list.test.ts
+++ b/packages/saltcorn-data/tests/list.test.ts
@@ -194,6 +194,88 @@ describe("Misc List views", () => {
     expect(vres1).toContain('<tr data-row-id="1">');
     expect(vres1).toContain("Leo Tolstoy");
   });
+  it("cell css formula applies class to td", async () => {
+    const view = await mkViewWithCfg({
+      configuration: {
+        layout: {
+          besides: [
+            {
+              contents: {
+                type: "field",
+                block: false,
+                fieldview: "show",
+                textStyle: "",
+                field_name: "pages",
+                configuration: {},
+                cell_css_formula: "pages < 800 ? 'text-danger fw-bold' : null",
+              },
+              alignment: "Default",
+              col_width_units: "px",
+              cell_css_formula: "pages < 800 ? 'text-danger fw-bold' : null",
+            },
+          ],
+          list_columns: true,
+        },
+        columns: [
+          {
+            type: "Field",
+            block: false,
+            fieldview: "show",
+            textStyle: "",
+            field_name: "pages",
+            configuration: {},
+            cell_css_formula: "pages < 800 ? 'text-danger fw-bold' : null",
+          },
+        ],
+      },
+    });
+    const vres = await view.run({}, mockReqRes);
+    // pages >= 800 — no danger class (align class only)
+    expect(vres).toContain('<td class="text-align-right">');
+    // pages < 800 (728) — gets the danger class alongside align class
+    expect(vres).toContain('<td class="text-align-right text-danger fw-bold">');
+  });
+
+  it("cell css formula does not affect rows when formula returns null", async () => {
+    const view = await mkViewWithCfg({
+      configuration: {
+        layout: {
+          besides: [
+            {
+              contents: {
+                type: "field",
+                block: false,
+                fieldview: "show",
+                textStyle: "",
+                field_name: "pages",
+                configuration: {},
+                cell_css_formula: "null",
+              },
+              alignment: "Default",
+              col_width_units: "px",
+              cell_css_formula: "null",
+            },
+          ],
+          list_columns: true,
+        },
+        columns: [
+          {
+            type: "Field",
+            block: false,
+            fieldview: "show",
+            textStyle: "",
+            field_name: "pages",
+            configuration: {},
+            cell_css_formula: "null",
+          },
+        ],
+      },
+    });
+    const vres = await view.run({}, mockReqRes);
+    expect(vres).not.toContain("text-danger");
+    expect(vres).toContain("728");
+  });
+
   it("grand total row sums numeric column", async () => {
     const view = await mkViewWithCfg({
       configuration: {
@@ -315,6 +397,7 @@ describe("Misc List views", () => {
     expect(vres).toContain("Subtotal");
     expect(vres).toContain("fw-bold");
   });
+
   it("list view with dropdown menu", async () => {
     const view = await mkViewWithCfg({
       configuration: {

--- a/packages/saltcorn-data/viewable_fields.ts
+++ b/packages/saltcorn-data/viewable_fields.ts
@@ -1424,6 +1424,11 @@ const get_viewable_fields = (
                 : undefined,
             header_underline: f.calculated && !f.stored ? true : undefined,
           };
+        if (fvrun && column.cell_css_formula) {
+          const formula = column.cell_css_formula;
+          fvrun.cell_class_fn = (row: Row) =>
+            eval_expression(formula, row, req.user, "Cell CSS formula") || null;
+        }
         if (column.click_to_edit) {
           const updateKey = (fvr: any, column_key?: any) => {
             const oldkey =

--- a/packages/saltcorn-markup/table.ts
+++ b/packages/saltcorn-markup/table.ts
@@ -256,14 +256,20 @@ const mkTable = (
         ...mkClickHandler(opts, v),
         ...(rowColor ? { style: { backgroundColor: rowColor } } : {}),
       },
-      hdrs.map((hdr: HeadersParams, hdr_ix) =>
-        td(
+      hdrs.map((hdr: HeadersParams, hdr_ix) => {
+        const cellClass = (hdr as any).cell_class_fn
+          ? (hdr as any).cell_class_fn(v)
+          : null;
+        return td(
           {
             style: {
               ...(hdr.width && opts.noHeader ? { width: hdr.width } : {}),
               ...(rowColor ? { backgroundColor: rowColor } : {}),
             },
-            ...(hdr.align ? { class: `text-align-${hdr.align}` } : {}),
+            class: [
+              hdr.align ? `text-align-${hdr.align}` : null,
+              cellClass || null,
+            ],
           },
           hdr_ix == 0 && opts.level_indicator && v._level
             ? "&nbsp;&nbsp;".repeat(v._level) + "└&nbsp;&nbsp;"
@@ -271,8 +277,8 @@ const mkTable = (
           cellWrapper(
             typeof hdr.key === "string" ? text(v[hdr.key]) : hdr.key(v)
           )
-        )
-      )
+        );
+      })
     );
   };
   const makeTotalRow = (rows: any[], label: string): string => {


### PR DESCRIPTION
## What this adds

A new **Cell CSS formula** option on every List view column. It accepts any JavaScript expression evaluated against the current row, and applies the return value as a CSS class directly on the `<td>` element.

**Example formulas:**
```js
// Finance: highlight negative values
amount < 0 ? 'text-danger fw-bold' : null

// Finance: flag values over budget
actual > budget ? 'table-warning' : null

// Traffic light by status
status === 'overdue' ? 'table-danger' : status === 'pending' ? 'table-warning' : null

// Bold the largest value
revenue === max_revenue ? 'fw-bold' : null
```

Any Bootstrap utility class works out of the box (`text-danger`, `text-success`, `fw-bold`, `table-warning`, `fst-italic`, etc.). Custom classes defined in site CSS also work. Returning `null`, `undefined`, or `false` leaves the cell completely unstyled — safe default with no output change.

---

## What it touches

| File | Change |
|---|---|
| `packages/saltcorn-markup/table.ts` | `val_row` now calls `hdr.cell_class_fn(row)` if present and merges the result into the `<td>` class alongside any existing alignment class |
| `packages/saltcorn-data/viewable_fields.ts` | For `Field` column type: if `column.cell_css_formula` is set, attaches a `cell_class_fn` closure using `eval_expression` to the header object |
| `packages/saltcorn-builder/src/components/elements/ListColumn.js` | Adds `cell_css_formula` string field to the per-column settings panel in the List view builder UI |
| `packages/saltcorn-data/tests/list.test.ts` | 2 new integration tests: one verifying class is applied to matching rows only, one verifying a null formula produces no output change |

---

## What it does NOT touch

- No database schema changes
- No changes to the row coloring feature (`_row_color_formula`) — cell and row coloring are fully independent and compose correctly
- No changes to any other view type (Show, Edit, Feed, etc.)
- No changes to how column content is rendered — only the wrapping `<td>` class is affected
- No changes to Join Field, Aggregation, ViewLink, Action, or any other column type — `cell_css_formula` is only wired to `Field` columns
- No API changes
- `expandColumns` fieldviews (e.g. `subfield`, `keys_expand_columns`) are not affected — the formula attaches after that branch

---

## How it composes with existing features

- **Row color + cell color**: both work simultaneously. Row color sets `backgroundColor` on the `<td>` via `style`; cell CSS sets a class. No conflict.
- **Column alignment**: existing `text-align-right` / `text-align-left` classes are preserved — the cell class is merged into an array alongside the alignment class.
- **Show if / column visibility**: cell formula only runs when the column is already visible; no interaction.

---

## Tests

Two new integration tests in `tests/list.test.ts` using the existing `books` fixture table:

1. **formula applies class** — `pages < 800 ? 'text-danger fw-bold' : null` produces `<td class="text-align-right text-danger fw-bold">` on the 728-page row and `<td class="text-align-right">` on the 967-page row
2. **null formula is a no-op** — formula returning `null` for all rows produces no extra classes and all row data still renders correctly