### PR TITLE
feat(table-provider): pass view state to provider getRows via selopts

### DIFF
--- a/packages/db-common/dbtypes.ts
+++ b/packages/db-common/dbtypes.ts
@@ -67,6 +67,7 @@ export type SelectOptions = {
   schema?: string;
   pk_name?: string;
   disable_ownership_postqfilter?: boolean;
+  state?: Record<string, any>;
 };
 export type JoinField = {
   ref: string;

--- a/packages/saltcorn-data/base-plugin/viewtemplates/list.ts
+++ b/packages/saltcorn-data/base-plugin/viewtemplates/list.ts
@@ -2013,6 +2013,7 @@ export default {
           ...q,
           forPublic: !req.user || req.user.role_id === 100,
           forUser: req.user,
+          state,
         });
 
         const joined_map: Record<PrimaryKeyValue, GenObj> = {};
@@ -2030,6 +2031,7 @@ export default {
           ...q,
           forPublic: !req.user || req.user.role_id === 100,
           forUser: req.user,
+          state,
         });
       //console.log("rows", rows);
 
@@ -2040,6 +2042,7 @@ export default {
           : await table.countRows(whereForCount, {
               forPublic: !req.user,
               forUser: req.user,
+              state,
               ...(default_state?._full_page_count === false
                 ? { limit: (q.offset || 0) + 4 * (q.limit || 100) + 1 }
                 : {}),

--- a/packages/saltcorn-data/models/table.ts
+++ b/packages/saltcorn-data/models/table.ts
@@ -4567,7 +4567,7 @@ ${rejectDetails}`,
    * @returns {Promise<object[]>}
    */
   async getJoinedRows(
-    opts: JoinOptions & ForUserRequest & { ignoreExternal?: boolean } = {}
+    opts: JoinOptions & ForUserRequest & { ignoreExternal?: boolean; state?: GenObj } = {}
   ): Promise<Array<Row>> {
     const fields = this.fields;
     const { forUser, forPublic, ...selopts1 } = opts;

--- a/packages/saltcorn-data/tests/mocks.ts
+++ b/packages/saltcorn-data/tests/mocks.ts
@@ -117,6 +117,31 @@ const plugin_with_routes = (): Plugin =>
           };
         },
       },
+      provtab_state: {
+        configuration_workflow: () =>
+          new Workflow({
+            steps: [
+              {
+                name: "step1",
+                form: (_context: any) =>
+                  new Form({
+                    fields: [{ name: "label", label: "Label", type: "String" }],
+                  }),
+              },
+            ],
+          }),
+        fields: async (_cfg: any) => [
+          { name: "key", label: "Key", type: "String", primary_key: true },
+          { name: "val", label: "Val", type: "String" },
+        ],
+        get_table(_cfg: any) {
+          return {
+            getRows: async (_where: any, selopts: any) => [
+              { key: "state_key", val: JSON.stringify(selopts?.state || null) },
+            ],
+          };
+        },
+      },
     },
     types: [
       {

--- a/packages/saltcorn-data/tests/table.test.ts
+++ b/packages/saltcorn-data/tests/table.test.ts
@@ -2677,6 +2677,36 @@ describe("table providers", () => {
   });
 });
 
+describe("table provider state passthrough", () => {
+  it("should register plugin with state provider", async () => {
+    getState().registerPlugin("mock_plugin", plugin_with_routes());
+  });
+  it("should create table with state-reflecting provider", async () => {
+    await Table.create("StateTable", {
+      provider_name: "provtab_state",
+      provider_cfg: { label: "test" },
+    });
+    await getState().refresh_tables();
+  });
+  it("state is forwarded to getRows when getJoinedRows is called with state", async () => {
+    const table = Table.findOne({ name: "StateTable" });
+    assertIsSet(table);
+    const rows = await table.getJoinedRows({
+      where: {},
+      state: { search: "hello", page: "2" },
+    });
+    expect(rows.length).toBe(1);
+    expect(JSON.parse(rows[0].val)).toEqual({ search: "hello", page: "2" });
+  });
+  it("state is null in selopts when getJoinedRows called without state", async () => {
+    const table = Table.findOne({ name: "StateTable" });
+    assertIsSet(table);
+    const rows = await table.getJoinedRows({ where: {} });
+    expect(rows.length).toBe(1);
+    expect(JSON.parse(rows[0].val)).toBeNull();
+  });
+});
+
 describe("distance ordering", () => {
   it("should create table", async () => {
     const tc = await Table.create("geotable1");

--- a/packages/saltcorn-data/tests/table.test.ts
+++ b/packages/saltcorn-data/tests/table.test.ts
@@ -2679,17 +2679,17 @@ describe("table providers", () => {
 
 describe("table provider state passthrough", () => {
   it("should register plugin with state provider", async () => {
-    getState().registerPlugin("mock_plugin", plugin_with_routes());
+    getState()!.registerPlugin("mock_plugin", plugin_with_routes());
   });
   it("should create table with state-reflecting provider", async () => {
     await Table.create("StateTable", {
       provider_name: "provtab_state",
       provider_cfg: { label: "test" },
     });
-    await getState().refresh_tables();
+    await getState()!.refresh_tables();
   });
   it("state is forwarded to getRows when getJoinedRows is called with state", async () => {
-    const table = Table.findOne({ name: "StateTable" });
+    const table = Table.findOne({ name: "StateTable" })!;
     assertIsSet(table);
     const rows = await table.getJoinedRows({
       where: {},
@@ -2699,7 +2699,7 @@ describe("table provider state passthrough", () => {
     expect(JSON.parse(rows[0].val)).toEqual({ search: "hello", page: "2" });
   });
   it("state is null in selopts when getJoinedRows called without state", async () => {
-    const table = Table.findOne({ name: "StateTable" });
+    const table = Table.findOne({ name: "StateTable" })!;
     assertIsSet(table);
     const rows = await table.getJoinedRows({ where: {} });
     expect(rows.length).toBe(1);


### PR DESCRIPTION
Fixes #4157

When a List view is backed by a table provider, the URL query state (filters,
pagination params, etc.) was converted into a SQL-style `where` object before
being passed to the provider's `getRows`. The raw state was never forwarded,
blocking providers that run custom code and need the original query params directly.

## Changes

**`packages/saltcorn-data/base-plugin/viewtemplates/list.ts`**
- Add `state` to both `getJoinedRows` calls (tree path and standard path)
- Add `state` to the `countRows` call

**`packages/saltcorn-data/models/table.ts`**
- Add optional `state?: GenObj` to the `getJoinedRows` opts type

**`packages/db-common/dbtypes.ts`**
- Add optional `state?: Record<string, any>` to `SelectOptions` (required for the `countRows` call path)

**No change needed in `plugin-helper.ts`** — `json_list_to_external_table`'s `getJoinedRows` already spreads opts into `getRows(where, rest)`, so `state` flows through automatically.

## Usage

A table provider's `getRows` function now receives the raw view state in `selopts.state`:

```js
get_table(cfg) {
  return {
    getRows: async (where, selopts) => {
      const state = selopts?.state; // { search: "foo", _page: "2", ... }
      // use state to call an external API, apply custom filtering, etc.
      return myData.filter(row => /* ... */);
    },
  };
}

## Tests

- `provtab_state` mock provider added to `mocks.ts` that reflects `selopts.state` in its returned row
- 4 new tests in `table.test.ts`: state forwarded when present, null when omitted
```