### PR TITLE
fix: include subfolder files in File field dropdown options (#4225)

### DIFF
--- a/packages/saltcorn-data/models/field.ts
+++ b/packages/saltcorn-data/models/field.ts
@@ -496,12 +496,13 @@ class Field implements AbstractField {
       const files = await File.find(
         this.attributes.folder
           ? { folder: this.attributes.folder }
-          : this.attributes.select_file_where || {}
+          : this.attributes.select_file_where || {},
+        { recursive: true }
       );
       this.options = files
         .filter((f) => !f.isDirectory)
         .map((f) => ({
-          label: f.filename,
+          label: f.path_to_serve,
           value: f.field_value,
         }));
       if (!this.required) this.options.unshift({ label: "", value: "" });

--- a/packages/saltcorn-data/tests/file.test.ts
+++ b/packages/saltcorn-data/tests/file.test.ts
@@ -68,6 +68,34 @@ describe("File class", () => {
     await f.delete();
   });
 
+  it("fill_fkey_options includes files from subfolders", async () => {
+    const subfolder = "opts_subfolder";
+    if (
+      !existsSync(
+        join(db.connectObj.file_store, db.getTenantSchema(), subfolder)
+      )
+    )
+      await File.new_folder(subfolder);
+    await File.from_contents(
+      "nested.txt",
+      "text/plain",
+      "nested file content",
+      1,
+      100,
+      subfolder
+    );
+    const field = new Field({
+      name: "attachment",
+      label: "Attachment",
+      type: "File",
+      required: false,
+      attributes: {},
+    });
+    await field.fill_fkey_options();
+    const labels = (field.options as any[]).map((o: any) => o.label);
+    expect(labels).toContain(`${subfolder}/nested.txt`);
+  });
+
   it("should find in subfolders", async () => {
     const subfolder = "subfolder";
     const fileName = "fileName2.html";


### PR DESCRIPTION

## Problem
File-type fields in views only showed files from the root file store (or a configured
folder). Files uploaded into subfolders were invisible in the select dropdown.

Root cause: fill_fkey_options() in models/field.ts called File.find() without
{ recursive: true }, so searcher() never traversed subdirectories. Additionally,
the label used f.filename (bare basename) which is ambiguous when identically-named
files exist in different subfolders.

## Changes
packages/saltcorn-data/models/field.ts
- Pass { recursive: true } to File.find() in the File-type branch of fill_fkey_options()
- Use f.path_to_serve as the option label (e.g. subfolder/image.jpg) instead of the
  bare f.filename
packages/saltcorn-data/tests/file.test.ts
- New test "fill_fkey_options includes files from subfolders" — creates a file in a
  subfolder, calls fill_fkey_options() on a File field, and asserts the option label
  contains the relative subfolder path

## Testing
Ran: node --test --test-name-pattern "fill_fkey_options" dist/tests/file.test.js
Result: 1 pass, 0 fail
Full file suite: 16 pass, 2 fail (the 2 failures are pre-existing sandbox tests
unrelated to this change).

Fixes #4225