### PR TITLE
fix: fall back to ILIKE when FTS search term is a stop word (#4233)

### DIFF
--- a/packages/db-common/internal.test.js
+++ b/packages/db-common/internal.test.js
@@ -262,13 +262,16 @@ describe("mkWhere", () => {
       values: ["foo bar"],
       where: `where to_tsvector('english', coalesce("description",'') || ' ' || coalesce("name",'')) @@ plainto_tsquery('english', $1)`,
     });
+    // Single-word prefix search: uses a CASE guard so PostgreSQL stop words
+    // (e.g. "on", "by", "a") fall back to ILIKE instead of throwing a
+    // tsquery syntax error.
     expect(
       mkWhere({
         _fts: { fields: [fld("name"), fld("description")], searchTerm: "foo" },
       })
     ).toStrictEqual({
-      values: ["foo:*"],
-      where: `where to_tsvector('english', coalesce("description",'') || ' ' || coalesce("name",'')) @@ to_tsquery('english', $1)`,
+      values: ["foo", "foo:*"],
+      where: `where CASE WHEN websearch_to_tsquery('english', $1) = ''::tsquery THEN coalesce("description",'') || ' ' || coalesce("name",'') ILIKE '%' || $1 || '%' ELSE to_tsvector('english', coalesce("description",'') || ' ' || coalesce("name",'')) @@ to_tsquery('english', $2) END`,
     });
     expect(
       mkWhere(

--- a/packages/db-common/internal.ts
+++ b/packages/db-common/internal.ts
@@ -165,10 +165,19 @@ const whereFTS = (
     return `${flds} LIKE '%' || ${phs.push(v.searchTerm)} || '%'`;
   else if (v.disable_fts)
     return `${flds} ILIKE '%' || ${phs.push(v.searchTerm)} || '%'`;
-  else
-    return `to_tsvector('${v.language || "english"}', ${flds}) @@ ${
-      actually_use_websearch ? "websearch_" : prefixMatch ? "" : `plain`
-    }to_tsquery('${v.language || "english"}', ${phs.push(searchTerm)})`;
+  else if (actually_use_websearch)
+    return `to_tsvector('${v.language || "english"}', ${flds}) @@ websearch_to_tsquery('${v.language || "english"}', ${phs.push(searchTerm)})`;
+  else if (prefixMatch) {
+    // Guard against stop words: to_tsquery('english','on:*') raises a syntax error
+    // because stop words are stripped to an empty query. Use websearch_to_tsquery as
+    // a probe — it returns ''::tsquery for stop words without erroring. When that
+    // happens, fall back to ILIKE so common words like "on", "by", "a" still match.
+    const lang = v.language || "english";
+    const rawTermPh = phs.push(v.searchTerm);
+    const prefixTermPh = phs.push(searchTerm);
+    return `CASE WHEN websearch_to_tsquery('${lang}', ${rawTermPh}) = ''::tsquery THEN ${flds} ILIKE '%' || ${rawTermPh} || '%' ELSE to_tsvector('${lang}', ${flds}) @@ to_tsquery('${lang}', ${prefixTermPh}) END`;
+  } else
+    return `to_tsvector('${v.language || "english"}', ${flds}) @@ plainto_tsquery('${v.language || "english"}', ${phs.push(searchTerm)})`;
 };
 
 export /**


### PR DESCRIPTION
## Problem

Single-word searches for common English words — "a", "as", "by", "on",
"once" — returned no results on PostgreSQL deployments. PostgreSQL's
to_tsquery('english', 'on:*') raises a syntax error because stop words
are stripped to an empty query before the :* prefix operator can be applied.

## Root cause

In packages/db-common/internal.ts, whereFTS() builds prefix-match queries
as to_tsquery('english', 'term:*'). This works for normal words but errors
for any term the English text-search dictionary classifies as a stop word.

## Fix

Wrap the prefix-match FTS clause in a CASE expression that uses
websearch_to_tsquery as a probe. websearch_to_tsquery silently returns
an empty tsquery for stop words (rather than erroring). When empty, the
CASE falls back to ILIKE substring matching, so stop words still match.
For normal words the probe is non-empty and the fast to_tsquery prefix
match runs as before.

Multi-word searches (plainto_tsquery) and SQLite (LIKE) are unaffected.

## Verified

Generated SQL confirmed in tests (46 pass, 0 fail in db-common) and
validated by inspecting mkWhere() output for "on", "time", and "hello world".

#4233 