### PR TITLE
fix: bold and underline text styles lost on links (#4234)

### DIFF
--- a/packages/saltcorn-markup/internal.ts
+++ b/packages/saltcorn-markup/internal.ts
@@ -121,8 +121,24 @@ const selfStylingTypes = new Set(["card", "container", "besides", "image"]);
 const textStyleToArray = (textStyle: any) =>
   Array.isArray(textStyle) ? textStyle : !textStyle ? [] : [textStyle];
 
+const textStyleClassNames = (textStyle: any): string[] =>
+  textStyleToArray(textStyle)
+    .filter((s: string) => s[0] !== "h")
+    .map((s: string) =>
+      s === "font-italic"
+        ? "fst-italic"
+        : s === "text-underline"
+          ? "text-decoration-underline"
+          : s
+    );
+
 const applyTextStyle = (segment: any, inner: string): string => {
-  const to_bs5 = (s: string) => (s === "font-italic" ? "fst-italic" : s);
+  const to_bs5 = (s: string) =>
+    s === "font-italic"
+      ? "fst-italic"
+      : s === "text-underline"
+        ? "text-decoration-underline"
+        : s;
   const styleArray = textStyleToArray(segment.textStyle);
   const hs = styleArray.find((s) => s[0] === "h");
   const klasses = styleArray.filter((s) => s[0] !== "h").map(to_bs5);
@@ -435,6 +451,9 @@ const render = ({
               segment.link_style || "",
               segment.link_size || "",
               segment.link_class || "",
+              // Apply textStyle classes directly on the <a> so they are not
+              // overridden by Bootstrap's .btn font-weight reset on the element.
+              ...textStyleClassNames(segment.textStyle),
             ],
             target: isWeb && segment.target_blank ? "_blank" : false,
             title: segment.link_title,

--- a/packages/saltcorn-markup/layout.ts
+++ b/packages/saltcorn-markup/layout.ts
@@ -120,8 +120,24 @@ const selfStylingTypes = new Set(["card", "container", "besides", "image"]);
 const textStyleToArray = (textStyle: any) =>
   Array.isArray(textStyle) ? textStyle : !textStyle ? [] : [textStyle];
 
+const textStyleClassNames = (textStyle: any): string[] =>
+  textStyleToArray(textStyle)
+    .filter((s: string) => s[0] !== "h")
+    .map((s: string) =>
+      s === "font-italic"
+        ? "fst-italic"
+        : s === "text-underline"
+          ? "text-decoration-underline"
+          : s
+    );
+
 const applyTextStyle = (segment: any, inner: string): string => {
-  const to_bs5 = (s: string) => (s === "font-italic" ? "fst-italic" : s);
+  const to_bs5 = (s: string) =>
+    s === "font-italic"
+      ? "fst-italic"
+      : s === "text-underline"
+        ? "text-decoration-underline"
+        : s;
   const styleArray = textStyleToArray(segment.textStyle);
   const hs = styleArray.find((s) => s[0] === "h");
   const klasses = styleArray.filter((s) => s[0] !== "h").map(to_bs5);
@@ -494,6 +510,9 @@ const render = ({
               segment.link_style &&
                 segment.link_style.includes("btn") &&
                 "d-inline-block",
+              // Apply textStyle classes directly on the <a> so they are not
+              // overridden by Bootstrap's .btn font-weight reset on the element.
+              ...textStyleClassNames(segment.textStyle),
             ],
             target: isWeb && segment.target_blank ? "_blank" : false,
             title: segment.link_title,


### PR DESCRIPTION
## Problem
Two text styles applied to links in the page builder disappeared at runtime:

- **Underline** never worked — the builder saves `text-underline` but Bootstrap 5's
  actual utility class is `text-decoration-underline`. The old name was silently
  ignored, so underline had no effect on any element type.
- **Bold** disappeared on button-style links (`btn btn-primary`, etc.) — Bootstrap's
  `.btn` rule sets `font-weight` via a CSS custom property directly on the `<a>`
  element, overriding the inherited `fw-bold` from the outer `<span>` wrapper that
  `applyTextStyle` produces.

Italics and monospace continued to work because `fst-italic` and `font-monospace`
are valid Bootstrap 5 classes and inherit correctly through the span wrapper.

## Fix

- Extended the `to_bs5` normaliser in both `layout.ts` and `internal.ts` to convert
  `text-underline` → `text-decoration-underline`.
- Added a `textStyleClassNames()` helper and spread the normalised classes directly
  onto the `<a>` element's class list, so they are not overrideable by Bootstrap's
  element-level button styles.

## Verified

Rendered output confirmed via node:
- Plain link with bold: `<a href="..." class="fw-bold">` ✓
- Button link with bold: `<a href="..." class="btn btn-primary fw-bold">` ✓
- Link with underline: `<a href="..." class="text-decoration-underline">` ✓


Tests: 98 pass, 2 fail (same 2 pre-existing locale-date failures on master).
Fixes #4234