### PR TITLE
fix: prevent 'undefined' string when embedded view has no matching row in list

### DIFF
--- a/packages/saltcorn-data/tests/list.test.ts
+++ b/packages/saltcorn-data/tests/list.test.ts
@@ -1491,4 +1491,44 @@ describe("dual joinfielss with fieldviews", () => {
     expect(vres1).toContain("FOO1BAR1");
   });
 });
+describe("embedded view in list container column (issue #4220)", () => {
+  it("should not render 'undefined' when a Show view is embedded in a Container column", async () => {
+    // Trigger the Container code path: contents with .above wraps to type:"container"
+    // which calls renderLayout with a blockDispatch.view handler.
+    // Before the fix, undefined from viewResults caused "undefined" string via string concat.
+    const view = await mkViewWithCfg({
+      configuration: {
+        layout: {
+          besides: [
+            {
+              contents: {
+                above: [
+                  {
+                    type: "view",
+                    view: "authorshow",
+                    relation: ".books",
+                    state: "shared",
+                  },
+                ],
+              },
+              alignment: "Default",
+              col_width_units: "px",
+            },
+          ],
+          list_columns: true,
+        },
+        columns: [
+          {
+            type: "View",
+            view: "authorshow",
+            relation: ".books",
+          },
+        ],
+      },
+    });
+    const vres1 = await view.run({}, mockReqRes);
+    expect(vres1).not.toContain(">undefined<");
+    expect(vres1).toContain("<table");
+  });
+});
 //sorting

--- a/packages/saltcorn-data/viewable_fields.ts
+++ b/packages/saltcorn-data/viewable_fields.ts
@@ -943,7 +943,7 @@ const get_viewable_fields = (
                   in_row_click
                 ),
                 view(column: any) {
-                  return viewResults?.[column.view + column.relation]?.(r);
+                  return viewResults?.[column.view + column.relation]?.(r) ?? "";
                 },
               },
               layout,

--- a/packages/saltcorn-markup/layout.ts
+++ b/packages/saltcorn-markup/layout.ts
@@ -297,7 +297,7 @@ const render = ({
     if (segment.minRole && role > segment.minRole) return "";
     if (segment.type && blockDispatch && blockDispatch[segment.type]) {
       const resp = blockDispatch[segment.type](segment, go);
-      if (resp !== false) return wrap(segment, isTop, ix, resp);
+      if (resp !== false) return wrap(segment, isTop, ix, resp ?? "");
       //else continue below
     }
     if (segment.type === "blank") {


### PR DESCRIPTION
**Problem**
When a Show view is embedded inside a Container column in a List view, and there is no matching related row for a given record, viewResults[view + relation](r) returns undefined. This value propagates through blockDispatch.view() → renderLayout() → wrap(), where the expression iconTag + inner coerces undefined to the string "undefined", rendering visible undefined text inside table cells.

**Root cause**
Two places needed fixing:

packages/saltcorn-markup/layout.ts — wrap(segment, isTop, ix, resp) receives resp = undefined when a blockDispatch handler returns nothing. iconTag + undefined → "undefined".
packages/saltcorn-data/viewable_fields.ts — The Container column's blockDispatch.view handler returns viewResults?.[...]?.(r) directly without a fallback, so undefined flows to renderLayout.

**Fix**
layout.ts: pass resp ?? "" to wrap() so undefined results from any blockDispatch handler never reach string concatenation.
viewable_fields.ts: return ?? "" from the Container column's view handler.

**Test**
Added a regression test in tests/list.test.ts that creates a List view with a besides column whose contents wraps a view segment inside an above array (the layout structure that triggers the Container code path). Asserts that the rendered output does not contain >undefined<.

Fixes #4220