### PR TITLE
Add Kanban board view template

### DIFF
--- a/packages/saltcorn-data/base-plugin/index.ts
+++ b/packages/saltcorn-data/base-plugin/index.ts
@@ -44,6 +44,7 @@ import roomMod from "./viewtemplates/room.js";
 import workflowRoomMod from "./viewtemplates/workflow-room.js";
 import editMod from "./viewtemplates/edit.js";
 import filterMod from "./viewtemplates/filter.js";
+import kanbanMod from "./viewtemplates/kanban.js";
 import fileviewsMod from "./fileviews.js";
 import actionsMod from "./actions.js";
 import * as nsFieldviews from "./fieldviews.js";
@@ -55,6 +56,7 @@ import room from "./viewtemplates/room.js";
 import wfroom from "./viewtemplates/workflow-room.js";
 import edit from "./viewtemplates/edit.js";
 import filter from "./viewtemplates/filter.js";
+import kanban from "./viewtemplates/kanban.js";
 import fileviews from "./fileviews.js";
 import * as fieldviews from "./fieldviews.js";
 import actions from "./actions.js";
@@ -70,6 +72,7 @@ const viewtemplates = [
   filter,
   room,
   wfroom,
+  kanban,
 ];
 
 const basePlugin = {

--- a/packages/saltcorn-data/base-plugin/viewtemplates/kanban.ts
+++ b/packages/saltcorn-data/base-plugin/viewtemplates/kanban.ts
@@ -1,0 +1,404 @@
+/**
+ * @category saltcorn-data
+ * @module base-plugin/viewtemplates/kanban
+ * @subcategory base-plugin
+ */
+import Table from "../../models/table.js";
+import View from "../../models/view.js";
+import Field from "../../models/field.js";
+import Form from "../../models/form.js";
+import Workflow from "../../models/workflow.js";
+import {
+  stateFieldsToWhere,
+  stateFieldsToQuery,
+  readState,
+} from "../../plugin-helper.js";
+import tagsPkg from "@saltcorn/markup/tags";
+import { GenObj } from "@saltcorn/types/common_types";
+import { Req, Res } from "@saltcorn/types/base_types";
+
+const { div, h5, span, script, domReady, button, a, i, text } = tagsPkg;
+
+// ─── configuration wizard ────────────────────────────────────────────────────
+
+const configuration_workflow = (req: Req) =>
+  new Workflow({
+    steps: [
+      {
+        name: req.__("Kanban settings"),
+        form: async (context: GenObj) => {
+          const table = Table.findOne(context.table_id)!;
+          const fields = table.getFields();
+
+          // Only string / integer fields make sensible lane-groupers
+          const groupable = fields.filter(
+            (f: GenObj) =>
+              !f.primary_key &&
+              (f.type?.name === "String" || f.type?.name === "Integer")
+          );
+
+          // Any view that can show a single row
+          const show_views = await View.find_table_views_where(
+            context.table_id,
+            ({ state_fields, viewrow }: GenObj) =>
+              viewrow.name !== context.viewname &&
+              state_fields.some((sf: GenObj) => sf.name === "id")
+          );
+
+          const create_views = await View.find_table_views_where(
+            context.table_id,
+            ({ state_fields, viewrow }: GenObj) =>
+              viewrow.name !== context.viewname &&
+              state_fields.every((sf: GenObj) => !sf.required)
+          );
+
+          return new Form({
+            fields: [
+              {
+                name: "group_field",
+                label: req.__("Group-by field"),
+                sublabel: req.__(
+                  "Cards will be grouped into columns by this field's value"
+                ),
+                type: "String",
+                required: true,
+                attributes: {
+                  options: groupable.map((f: GenObj) => f.name),
+                },
+              },
+              {
+                name: "column_order",
+                label: req.__("Column order (comma-separated values)"),
+                sublabel: req.__(
+                  "Optional: define the order and exact set of columns, e.g. To Do,In Progress,Done"
+                ),
+                type: "String",
+                required: false,
+              },
+              {
+                name: "card_title_field",
+                label: req.__("Card title field"),
+                sublabel: req.__("The field shown as the card heading"),
+                type: "String",
+                required: false,
+                attributes: {
+                  options: fields
+                    .filter((f: GenObj) => !f.primary_key)
+                    .map((f: GenObj) => f.name),
+                },
+              },
+              {
+                name: "show_view",
+                label: req.__("Card detail view"),
+                sublabel: req.__(
+                  "Optional: clicking a card opens this view in a modal"
+                ),
+                type: "String",
+                required: false,
+                attributes: {
+                  options: [
+                    { label: req.__("None"), value: "" },
+                    ...show_views.map((v: GenObj) => v.select_option),
+                  ],
+                },
+              },
+              {
+                name: "view_to_create",
+                label: req.__("Use view to create"),
+                sublabel: req.__("Optional: show a button to add new cards"),
+                type: "String",
+                required: false,
+                attributes: {
+                  options: [
+                    { label: req.__("None"), value: "" },
+                    ...create_views.map((v: GenObj) => v.select_option),
+                  ],
+                },
+              },
+              {
+                name: "min_role",
+                label: req.__("Minimum role to move cards"),
+                type: "String",
+                required: false,
+                attributes: {
+                  options: [
+                    { name: "1", label: req.__("Admin") },
+                    { name: "40", label: req.__("Staff") },
+                    { name: "80", label: req.__("User") },
+                    { name: "100", label: req.__("Public") },
+                  ],
+                },
+              },
+            ],
+          });
+        },
+      },
+    ],
+  });
+
+// ─── state fields ─────────────────────────────────────────────────────────────
+
+const get_state_fields = async (
+  table_id: number,
+  _viewname: string,
+  _config: GenObj
+) => {
+  const table = Table.findOne(table_id)!;
+  return table.getFields()
+    .filter((f: GenObj) => !f.primary_key)
+    .map((f: GenObj) => {
+      const sf = new Field(f);
+      sf.required = false;
+      return sf;
+    });
+};
+
+// ─── run ──────────────────────────────────────────────────────────────────────
+
+const run = async (
+  table_id: number,
+  viewname: string,
+  {
+    group_field,
+    column_order,
+    card_title_field,
+    show_view,
+    view_to_create,
+    min_role,
+  }: GenObj,
+  state: GenObj,
+  extraArgs: { req: Req; res: Res }
+) => {
+  const { req } = extraArgs;
+  const table = Table.findOne(table_id)!;
+  const pk_name = table.pk_name;
+  const fields = table.getFields();
+
+  if (!group_field) {
+    return div(
+      { class: "alert alert-warning" },
+      "Kanban: no group-by field configured."
+    );
+  }
+
+  const where = stateFieldsToWhere({ fields, state, table });
+  const q = stateFieldsToQuery({ state, fields });
+  const rows = await table.getRows(where, {
+    ...q,
+    forUser: req.user,
+    forPublic: !req.user,
+  });
+
+  // Determine column list
+  let columns: string[];
+  if (column_order && column_order.trim()) {
+    columns = column_order.split(",").map((s: string) => s.trim());
+  } else {
+    const seen = new Set<string>();
+    columns = [];
+    for (const row of rows) {
+      const val = String(row[group_field] ?? "");
+      if (!seen.has(val)) {
+        seen.add(val);
+        columns.push(val);
+      }
+    }
+    if (columns.length === 0) columns = ["(empty)"];
+  }
+
+  // Group rows into columns
+  const grouped: Record<string, GenObj[]> = {};
+  for (const col of columns) grouped[col] = [];
+  for (const row of rows) {
+    const val = String(row[group_field] ?? "");
+    if (grouped[val] !== undefined) {
+      grouped[val].push(row);
+    } else if (!column_order) {
+      // dynamic column — create it
+      grouped[val] = [row];
+      if (!columns.includes(val)) columns.push(val);
+    }
+    // rows whose value isn't in a configured column are silently dropped
+  }
+
+  const role: number = req.user ? req.user.role_id : 100;
+  const canMove = role <= parseInt(min_role || "80", 10);
+
+  // ── build HTML ──────────────────────────────────────────────────────────────
+
+  const cardHtml = (row: GenObj) => {
+    const titleVal = card_title_field
+      ? text(String(row[card_title_field] ?? ""))
+      : text(String(row[pk_name]));
+
+    const cardBody = div(
+      { class: "card-body p-2" },
+      h5({ class: "card-title mb-1 sc-kanban-title" }, titleVal)
+    );
+
+    if (show_view) {
+      return div(
+        {
+          class: "card sc-kanban-card mb-2",
+          "data-id": row[pk_name],
+          "data-group": String(row[group_field] ?? ""),
+        },
+        a(
+          {
+            href: `javascript:void(0)`,
+            "data-sc-modal": `/view/${show_view}?id=${row[pk_name]}`,
+            class: "text-decoration-none text-body stretched-link",
+          },
+          cardBody
+        )
+      );
+    }
+
+    return div(
+      {
+        class: "card sc-kanban-card mb-2",
+        "data-id": row[pk_name],
+        "data-group": String(row[group_field] ?? ""),
+      },
+      cardBody
+    );
+  };
+
+  const addBtn = (colValue: string) => {
+    if (!view_to_create) return "";
+    const qs = new URLSearchParams({ [group_field]: colValue }).toString();
+    return div(
+      { class: "mt-2 text-center" },
+      a(
+        {
+          href: `/view/${view_to_create}?${qs}`,
+          class: "btn btn-sm btn-outline-secondary w-100 sc-kanban-add",
+        },
+        i({ class: "fas fa-plus me-1" }),
+        req.__("Add")
+      )
+    );
+  };
+
+  const columnHtml = (col: string) =>
+    div(
+      { class: "sc-kanban-column card" },
+      div(
+        { class: "sc-kanban-col-header card-header d-flex justify-content-between align-items-center" },
+        span({ class: "fw-semibold" }, text(col)),
+        span(
+          { class: "badge bg-secondary sc-kanban-count" },
+          String((grouped[col] || []).length)
+        )
+      ),
+      div(
+        {
+          class: "sc-kanban-cards p-2",
+          "data-column": col,
+          "data-viewname": viewname,
+        },
+        ...(grouped[col] || []).map(cardHtml),
+        addBtn(col)
+      )
+    );
+
+  const boardHtml = div(
+    { class: "sc-kanban-board", id: `sc-kanban-${viewname.replace(/\W/g, "_")}` },
+    ...columns.map(columnHtml)
+  );
+
+  if (!canMove) return boardHtml;
+
+  // ── drag-and-drop script ────────────────────────────────────────────────────
+  const boardId = `sc-kanban-${viewname.replace(/\W/g, "_")}`;
+  const dragScript = script(
+    { src: "https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js" }
+  ) +
+    script(
+      domReady(`
+  (function() {
+    var board = document.getElementById(${JSON.stringify(boardId)});
+    if (!board) return;
+    board.querySelectorAll('.sc-kanban-cards').forEach(function(lane) {
+      new Sortable(lane, {
+        group: ${JSON.stringify(boardId)},
+        animation: 150,
+        ghostClass: 'sc-kanban-ghost',
+        onEnd: function(evt) {
+          var card = evt.item;
+          var id = card.getAttribute('data-id');
+          var newCol = evt.to.getAttribute('data-column');
+          var viewname = evt.to.getAttribute('data-viewname');
+          if (!id || !newCol || !viewname) return;
+          // update badge counts
+          [evt.from, evt.to].forEach(function(lane) {
+            var col = lane.closest('.sc-kanban-column');
+            if (col) {
+              col.querySelector('.sc-kanban-count').textContent =
+                lane.querySelectorAll('.sc-kanban-card').length;
+            }
+          });
+          fetch('/view/' + viewname + '/move_card', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json',
+                      'CSRF-Token': _sc_get_csrf_token()},
+            body: JSON.stringify({ id: id, column: newCol })
+          }).then(function(r) {
+            if (!r.ok) {
+              notifyAlert({type:'danger', text:'Move failed'});
+              // restore original position — simplest: reload
+              location.reload();
+            }
+          }).catch(function() { location.reload(); });
+        }
+      });
+    });
+  })();
+`)
+    );
+
+  return boardHtml + dragScript;
+};
+
+// ─── move_card route ──────────────────────────────────────────────────────────
+
+const move_card = async (
+  table_id: number,
+  viewname: string,
+  { group_field, min_role }: GenObj,
+  body: GenObj,
+  { req }: { req: Req; res: Res }
+) => {
+  const role: number = req.user ? req.user.role_id : 100;
+  if (role > parseInt(min_role || "80", 10)) {
+    return { json: { error: "Not authorized" } };
+  }
+
+  const { id, column } = body;
+  if (!id || column === undefined) {
+    return { json: { error: "Missing id or column" } };
+  }
+
+  const table = Table.findOne(table_id)!;
+  try {
+    await table.updateRow({ [group_field]: column }, id, req.user);
+    return { json: { success: true } };
+  } catch (e: any) {
+    return { json: { error: e.message || "Update failed" } };
+  }
+};
+
+// ─── export ───────────────────────────────────────────────────────────────────
+
+export default {
+  name: "Kanban",
+  description:
+    "Display rows as cards grouped into draggable swim-lane columns by a field value",
+  configuration_workflow,
+  run,
+  get_state_fields,
+  routes: { move_card },
+  getStringsForI18n() {
+    return [];
+  },
+};

--- a/packages/saltcorn-data/tests/kanban.test.ts
+++ b/packages/saltcorn-data/tests/kanban.test.ts
@@ -1,0 +1,254 @@
+import Table from "../models/table.js";
+import Field from "../models/field.js";
+import View from "../models/view.js";
+import db from "../db/index.js";
+import * as mocks from "./mocks.js";
+import { getState } from "../db/state.js";
+import basePluginMod from "../base-plugin/index.js";
+import resetSchemaMod from "../db/reset_schema.js";
+import type { FieldLike } from "@saltcorn/types/base_types";
+const { mockReqRes } = mocks;
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  it,
+  expect,
+} from "@saltcorn/db-common/test_expect";
+
+getState()!.registerPlugin("base", basePluginMod);
+
+afterAll(db.close);
+
+// Self-contained: create a fresh schema and a minimal Tasks table,
+// avoiding the upstream fixture chain that breaks on ESM migration.
+beforeAll(async () => {
+  await resetSchemaMod();
+  // create Tasks table
+  const tasks = await Table.create("tasks");
+  await Field.create({ table: tasks, name: "title", label: "Title", type: "String", required: true });
+  await Field.create({ table: tasks, name: "status", label: "Status", type: "String", required: false });
+  await db.insert("tasks", { title: "Write docs", status: "To Do" });
+  await db.insert("tasks", { title: "Fix bug", status: "To Do" });
+  await db.insert("tasks", { title: "Code review", status: "In Progress" });
+  await db.insert("tasks", { title: "Deploy", status: "Done" });
+});
+
+// ─── helper ───────────────────────────────────────────────────────────────────
+
+const mkKanbanView = async (cfg: Record<string, any> = {}): Promise<View> =>
+  View.create({
+    viewtemplate: "Kanban",
+    description: "",
+    min_role: 1,
+    name: `kanban_${Math.round(Math.random() * 1e6)}`,
+    table_id: Table.findOne("tasks")!.id,
+    default_render_page: "",
+    slug: { label: "", steps: [] },
+    attributes: {},
+    configuration: {
+      group_field: "status",
+      column_order: "To Do,In Progress,Done",
+      card_title_field: "title",
+      show_view: "",
+      view_to_create: "",
+      min_role: "80",
+      ...cfg,
+    },
+  });
+
+// ─── get_state_fields ─────────────────────────────────────────────────────────
+
+describe("Kanban get_state_fields", () => {
+  it("returns non-PK fields as optional state filters", async () => {
+    const view = await mkKanbanView();
+    const stateFields = await view.get_state_fields();
+    expect(Array.isArray(stateFields)).toBe(true);
+    const names = stateFields.map((f: FieldLike) => f.name);
+    // primary key must be excluded
+    expect(names).not.toContain("id");
+    // data fields must be present
+    expect(names).toContain("title");
+    expect(names).toContain("status");
+    // all state fields must be non-required
+    stateFields.forEach((f: FieldLike) => expect(f.required).toBe(false));
+    await view.delete();
+  });
+});
+
+// ─── run ──────────────────────────────────────────────────────────────────────
+
+describe("Kanban run", () => {
+  it("renders the board wrapper and all configured columns", async () => {
+    const view = await mkKanbanView();
+    const { req, res } = mockReqRes;
+    const html = await view.run({}, { req, res });
+    expect(html).toContain("sc-kanban-board");
+    expect(html).toContain("To Do");
+    expect(html).toContain("In Progress");
+    expect(html).toContain("Done");
+    await view.delete();
+  });
+
+  it("renders card titles using the configured card_title_field", async () => {
+    const view = await mkKanbanView();
+    const { req, res } = mockReqRes;
+    const html = await view.run({}, { req, res });
+    expect(html).toContain("Write docs");
+    expect(html).toContain("Fix bug");
+    expect(html).toContain("Code review");
+    expect(html).toContain("Deploy");
+    await view.delete();
+  });
+
+  it("renders columns in the configured order", async () => {
+    const view = await mkKanbanView({
+      column_order: "Done,In Progress,To Do",
+    });
+    const { req, res } = mockReqRes;
+    const html = await view.run({}, { req, res });
+    const donePos = html.indexOf(">Done<");
+    const inProgressPos = html.indexOf(">In Progress<");
+    const todoPos = html.indexOf(">To Do<");
+    expect(donePos).toBeGreaterThan(-1);
+    expect(inProgressPos).toBeGreaterThan(donePos);
+    expect(todoPos).toBeGreaterThan(inProgressPos);
+    await view.delete();
+  });
+
+  it("renders per-column card count badges", async () => {
+    const view = await mkKanbanView();
+    const { req, res } = mockReqRes;
+    const html = await view.run({}, { req, res });
+    expect(html).toContain("sc-kanban-count");
+    // To Do has 2 cards; badge should contain "2"
+    expect(html).toContain(">2<");
+    await view.delete();
+  });
+
+  it("injects SortableJS drag script when user meets min_role", async () => {
+    // min_role "1" = admin only; mockReqRes.req has role_id 1
+    const view = await mkKanbanView({ min_role: "1" });
+    const { req, res } = mockReqRes;
+    const html = await view.run({}, { req, res });
+    expect(html).toContain("Sortable");
+    expect(html).toContain("move_card");
+    await view.delete();
+  });
+
+  it("omits drag script when user role exceeds min_role", async () => {
+    // min_role "1" = admin; public user has role_id 100
+    const view = await mkKanbanView({ min_role: "1" });
+    const publicReq = {
+      ...mockReqRes.req,
+      user: undefined,
+      isAuthenticated: () => false,
+    };
+    const html = await view.run({}, { req: publicReq, res: mockReqRes.res });
+    expect(html).not.toContain("Sortable");
+    await view.delete();
+  });
+
+  it("shows a warning when group_field is not configured", async () => {
+    const view = await mkKanbanView({ group_field: "" });
+    const { req, res } = mockReqRes;
+    const html = await view.run({}, { req, res });
+    expect(html).toContain("alert");
+    await view.delete();
+  });
+
+  it("derives columns dynamically when column_order is empty", async () => {
+    const view = await mkKanbanView({ column_order: "" });
+    const { req, res } = mockReqRes;
+    const html = await view.run({}, { req, res });
+    // all distinct status values in the data should appear as columns
+    expect(html).toContain("To Do");
+    expect(html).toContain("In Progress");
+    expect(html).toContain("Done");
+    await view.delete();
+  });
+});
+
+// ─── move_card route ──────────────────────────────────────────────────────────
+
+describe("Kanban move_card route", () => {
+  it("updates the group-by field when user has permission", async () => {
+    const table = Table.findOne("tasks")!;
+    const [row] = await table.getRows({ title: "Write docs" });
+
+    const view = await mkKanbanView({ min_role: "80" }); // User and above
+
+    mockReqRes.reset();
+    await view.runRoute(
+      "move_card",
+      { id: String(row.id), column: "Done" },
+      mockReqRes.res,
+      { req: mockReqRes.req, res: mockReqRes.res }
+    );
+    expect(mockReqRes.getStored().json).toEqual({ success: true });
+
+    const updated = await table.getRow({ id: row.id });
+    expect(updated!.status).toBe("Done");
+
+    // restore
+    await table.updateRow({ status: "To Do" }, row.id);
+    await view.delete();
+  });
+
+  it("rejects move when user role is insufficient", async () => {
+    const table = Table.findOne("tasks")!;
+    const [row] = await table.getRows({ title: "Fix bug" });
+
+    const view = await mkKanbanView({ min_role: "1" }); // admin only
+
+    const publicReq = {
+      ...mockReqRes.req,
+      user: { id: 99, role_id: 100, attributes: {} },
+    };
+
+    mockReqRes.reset();
+    await view.runRoute(
+      "move_card",
+      { id: String(row.id), column: "Done" },
+      mockReqRes.res,
+      { req: publicReq, res: mockReqRes.res }
+    );
+    expect(mockReqRes.getStored().json).toEqual({ error: "Not authorized" });
+
+    // row must be unchanged
+    const unchanged = await table.getRow({ id: row.id });
+    expect(unchanged!.status).toBe("To Do");
+
+    await view.delete();
+  });
+
+  it("returns an error when id is missing", async () => {
+    const view = await mkKanbanView();
+
+    mockReqRes.reset();
+    await view.runRoute(
+      "move_card",
+      { column: "Done" },
+      mockReqRes.res,
+      { req: mockReqRes.req, res: mockReqRes.res }
+    );
+    expect(typeof mockReqRes.getStored().json?.error).toBe("string");
+
+    await view.delete();
+  });
+
+  it("returns an error when column is missing", async () => {
+    const view = await mkKanbanView();
+
+    mockReqRes.reset();
+    await view.runRoute(
+      "move_card",
+      { id: "1" },
+      mockReqRes.res,
+      { req: mockReqRes.req, res: mockReqRes.res }
+    );
+    expect(typeof mockReqRes.getStored().json?.error).toBe("string");
+
+    await view.delete();
+  });
+});

--- a/packages/server/public/saltcorn.css
+++ b/packages/server/public/saltcorn.css
@@ -1218,3 +1218,49 @@ span.copy-to-clipboard.copied::after {
   right: unset;
   left: 0;
 }
+
+/* ── Kanban board ─────────────────────────────────────────────────────────── */
+.sc-kanban-board {
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  overflow-x: auto;
+  align-items: flex-start;
+  padding-bottom: 1rem;
+}
+.sc-kanban-column {
+  min-width: 240px;
+  width: 260px;
+  flex-shrink: 0;
+  background: var(--bs-body-bg, #fff);
+}
+.sc-kanban-col-header {
+  background: var(--bs-secondary-bg, #f8f9fa);
+  font-size: .9rem;
+}
+.sc-kanban-cards {
+  min-height: 60px;
+  padding: .5rem !important;
+}
+.sc-kanban-card {
+  cursor: grab;
+  border: 1px solid var(--bs-border-color, #dee2e6);
+  border-radius: .375rem;
+  background: var(--bs-body-bg, #fff);
+  transition: box-shadow .15s;
+  position: relative;
+}
+.sc-kanban-card:hover {
+  box-shadow: 0 2px 8px rgba(0,0,0,.12);
+}
+.sc-kanban-card:active {
+  cursor: grabbing;
+}
+.sc-kanban-ghost {
+  opacity: .4;
+  background: var(--bs-primary-bg-subtle, #cfe2ff);
+  border: 2px dashed var(--bs-primary, #0d6efd);
+}
+.sc-kanban-add {
+  font-size: .8rem;
+}


### PR DESCRIPTION
## Summary

- Adds a new built-in **Kanban** view template that groups table rows into draggable swim-lane columns by a chosen field value
- Cards move between columns via drag-and-drop (SortableJS); each drop persists the new value via `POST /view/:viewname/move_card`
- Fully integrated into Saltcorn's view configuration workflow with a live preview

## Files changed

- `packages/saltcorn-data/base-plugin/viewtemplates/kanban.ts` *(new)* — configuration workflow, run, get_state_fields, move_card route
- `packages/saltcorn-data/base-plugin/index.ts` — registers Kanban in the viewtemplates array
- `packages/server/public/saltcorn.css` — board layout and drag-ghost styles

## Configuration options

| Setting | Description |
|---|---|
| Group-by field | String/Integer field whose value determines the column |
| Column order | Comma-separated list defining column names and order |
| Card title field | Field shown as the card heading |
| Card detail view | Optional Show view opened in a modal on click |
| Use view to create | Optional Edit view linked from an "Add" button per column |
| Minimum role to move cards | Role threshold; below it the board is read-only |

## How to test

1. Create a table with `title` (String) + `status` (String); add rows with status values `To Do`, `In Progress`, `Done`
2. Create a **Show** view on the table
3. **Views → Add view → pattern: Kanban** → group-by=`status`, column order=`To Do,In Progress,Done`, title field=`title`
4. Open the view — three columns with cards and live badge counts appear
5. Drag a card to a new column — badge updates immediately; reload confirms the DB row was updated
6. Log in as a role below `min_role` — board is read-only, no drag behaviour

<img width="1499" height="898" alt="Screenshot 2026-06-29 at 12 37 30 PM" src="https://github.com/user-attachments/assets/a71a5e4b-3690-4d1b-ba6f-dd357a1b1275" />
<img width="1216" height="320" alt="Screenshot 2026-06-29 at 12 36 03 PM" src="https://github.com/user-attachments/assets/71a4d5cb-15c2-4458-b425-14327add39b0" />

