### PR TITLE
perf(rls): wrap current_setting() in generated ownership/role policies so it evaluates once per statement

### DIFF
--- a/packages/saltcorn-data/models/expression.ts
+++ b/packages/saltcorn-data/models/expression.ts
@@ -1140,7 +1140,7 @@ function formulaToRlsUsing(
     return null;
   }
 
-  const curUserId = `nullif(current_setting('app.current_user_id', true), '')::integer`;
+  const curUserId = `(select nullif(current_setting('app.current_user_id', true), '')::integer)`;
 
   function transpile(node: any): string | null {
     switch (node.type) {

--- a/packages/saltcorn-data/models/table.ts
+++ b/packages/saltcorn-data/models/table.ts
@@ -559,7 +559,7 @@ class Table implements AbstractTable {
     if (this.ownership_field_id) {
       const owner_field = this.owner_fieldname();
       if (!owner_field) return null;
-      const curUserId = `nullif(current_setting('app.current_user_id', true), '')::integer`;
+      const curUserId = `(select nullif(current_setting('app.current_user_id', true), '')::integer)`;
       return `${curUserId} = "${sqlsanitize(owner_field)}"`;
     }
 
@@ -607,7 +607,7 @@ class Table implements AbstractTable {
 
     // Separate policies for read and write so the write threshold cannot
     // widen SELECT visibility via PG's OR-of-permissive-policies rule.
-    const roleGuc = `coalesce(nullif(current_setting('app.current_user_role', true), '')::integer, 1)`;
+    const roleGuc = `(select coalesce(nullif(current_setting('app.current_user_role', true), '')::integer, 1))`;
     await db.query(`
       CREATE POLICY sc_rls_elevated ON ${tbl}
       FOR SELECT

--- a/packages/saltcorn-data/tests/auxtest.test.ts
+++ b/packages/saltcorn-data/tests/auxtest.test.ts
@@ -193,7 +193,7 @@ describe("generate_joined_query", () => {
 
 describe("formulaToRlsUsing", () => {
   const schema = `"public".`;
-  const curUserId = `nullif(current_setting('app.current_user_id', true), '')::integer`;
+  const curUserId = `(select nullif(current_setting('app.current_user_id', true), '')::integer)`;
 
   it("user.X===id (reverse FK)", () => {
     expect(formulaToRlsUsing("user.manager===id", schema)).toBe(


### PR DESCRIPTION
## What

The Postgres RLS policies generated in `packages/saltcorn-data/models/table.ts` embed two session (GUC) lookups directly in their `USING` / `WITH CHECK` predicates:

- `nullif(current_setting('app.current_user_id', true), '')::integer` &nbsp;(the `sc_rls_owner` ownership check)
- `coalesce(nullif(current_setting('app.current_user_role', true), '')::integer, 1)` &nbsp;(the `sc_rls_elevated*` role checks)

Left unwrapped in the predicate, Postgres re-evaluates the `current_setting()` call **once per row scanned** — from the planner's point of view a function call could vary per row, so it can't hoist it out of the scan.

## Fix

Wrap each session lookup in a scalar sub-select — `(select …)` — so the planner evaluates it **once per statement** as an InitPlan and reuses the value for every row:

```
-- before:  current_setting('app.current_user_id', true) ...  = owner_id    -- per row
-- after:   (select current_setting('app.current_user_id', true) ...) = owner_id  -- per statement
```

A GUC is constant within a statement, so the returned value is identical — this is purely a planner optimization (same rows in, same rows out, fewer lookups). Both template fragments are wrapped, so every `sc_rls_owner` / `sc_rls_elevated*` policy Saltcorn emits inherits it. It's the standard InitPlan trick for session-stable calls in RLS predicates (the same one [Supabase documents](https://supabase.com/docs/guides/database/postgres/row-level-security#call-functions-with-select) for `auth.*()` / `current_setting()`).

## Notes

- Two one-line changes to the policy-template fragments; all downstream `CREATE POLICY` emissions inherit the wrap.
- I couldn't run the full JS/TS suite locally, but the change is value-preserving: the `qual` assertions in `db.test.ts` are substring checks on `owner_id` / `current_setting` (both still present after the wrap), and the row-visibility tests are unaffected because the computed value doesn't change.
- Surfaced by [pgrls](https://github.com/pgrls/pgrls) (`PERF001`), an open-source Postgres RLS linter / verifier.
