### PR TITLE
multinode workflow mutex

### DIFF
--- a/infosec-scan/py-sectest/workflow_mutex_test.py
+++ b/infosec-scan/py-sectest/workflow_mutex_test.py
@@ -1,0 +1,132 @@
+import re
+import threading
+import logging
+from scsession import SaltcornSession
+
+logging.basicConfig(
+  level=logging.INFO,
+  format='[%(asctime)s] %(levelname)s - %(message)s',
+  datefmt='%Y-%m-%d %H:%M:%S'
+)
+
+logger = logging.getLogger(__name__)
+
+email = 'admin@foo.com'
+password = 'AhGGr6rhu45'
+
+LOCK_NAME = 'mutex-test-shared-lock'
+START_MARKER = 'mutex-test-start'
+END_MARKER = 'mutex-test-end'
+
+# Logs start/end rows into "books" (reused as a scratch log) around a sleep.
+# Serialized: start,end,start,end. Interleaved (mutex failed): start,start,end,end.
+STEP_CODE = (
+  'const table = Table.findOne({name: "books"});\n'
+  f'await table.insertRow({{author: "{START_MARKER}", pages: 0}});\n'
+  'await sleep(1500);\n'
+  f'await table.insertRow({{author: "{END_MARKER}", pages: 0}});\n'
+)
+
+
+def login(sess):
+  sess.get('/auth/login')
+  sess.postForm('/auth/login', {
+    'email': email,
+    'password': password,
+    '_csrf': sess.csrf(),
+  })
+
+
+class Test:
+  def setup_class(self):
+    SaltcornSession.reset_to_fixtures()
+    self.sess1 = SaltcornSession(port=3001, env_vars={
+        "SALTCORN_MULTI_NODE": True,
+    }, pipe_output=True)
+    self.sess2 = SaltcornSession(port=3002, env_vars={
+        "SALTCORN_MULTI_NODE": True,
+    }, pipe_output=True)
+
+  def teardown_class(self):
+    self.sess1.close()
+    self.sess2.close()
+
+  # Create a "Never" workflow trigger with a single run_js_code step that
+  # has a "Lock name" set (step-scoped mutex, models/mutex.ts withLock).
+  # Returns the new trigger's id.
+  def _create_locked_workflow(self):
+    logger.info("Creating workflow trigger")
+    self.sess1.get('/actions/new')
+    self.sess1.postForm('/actions/new', {
+      'name': 'mutex_test_wf',
+      'when_trigger': 'Never',
+      'table_id': '',
+      'action': 'Workflow',
+      'description': '',
+      '_csrf': self.sess1.csrf(),
+    })
+    assert self.sess1.status == 302, self.sess1.content
+    # redirect_url looks like /actions/configure/<trigger_id>
+    trigger_id = self.sess1.redirect_url.rstrip('/').split('/')[-1]
+    assert trigger_id.isdigit(), self.sess1.redirect_url
+
+    logger.info(f"Adding locked step to trigger {trigger_id}")
+    self.sess1.get(f'/actions/stepedit/{trigger_id}')
+    self.sess1.postForm(f'/actions/stepedit/{trigger_id}', {
+      'wf_step_name': 'locked_step',
+      'wf_action_name': 'run_js_code',
+      'wf_initial_step': 'on',
+      'wf_only_if': '',
+      'wf_next_step': '',
+      'mutex_enabled': 'on',
+      'mutex_lock_name': f'"{LOCK_NAME}"',
+      'code': STEP_CODE,
+      'run_where': 'Server',
+      '_csrf': self.sess1.csrf(),
+    })
+    assert self.sess1.status == 302, self.sess1.content
+
+    return trigger_id
+
+  def _run_count(self):
+    out = SaltcornSession.cli(
+      "run-sql",
+      "--sql",
+      f"select author from books where author like 'mutex-test-%' order by id",
+    )
+    return re.findall(r"'(mutex-test-(?:start|end))'", out)
+
+  # TEST:
+  # fire the same locked workflow concurrently from two separate node
+  # processes (sharing one database) and check that their critical
+  # sections did not interleave.
+  def test_step_scoped_lock_serializes_across_nodes(self):
+    logger.info("sess1 and sess2 logging in")
+    login(self.sess1)
+    login(self.sess2)
+
+    trigger_id = self._create_locked_workflow()
+
+    results = {}
+
+    def fire(sess, key):
+      sess.get(f'/actions/testrun/{trigger_id}')
+      results[key] = sess.status
+
+    t1 = threading.Thread(target=fire, args=(self.sess1, 'sess1'))
+    t2 = threading.Thread(target=fire, args=(self.sess2, 'sess2'))
+    t1.start()
+    t2.start()
+    t1.join(timeout=30)
+    t2.join(timeout=30)
+
+    assert results.get('sess1') == 302, self.sess1.content
+    assert results.get('sess2') == 302, self.sess2.content
+
+    markers = self._run_count()
+    logger.info(f"Observed marker sequence: {markers}")
+    assert len(markers) == 4, markers
+    assert markers == [START_MARKER, END_MARKER, START_MARKER, END_MARKER], (
+      f"expected serialized start,end,start,end but got {markers} - "
+      "this would mean the two nodes' locked steps interleaved"
+    )

--- a/infosec-scan/py-sectest/workflow_mutex_test.py
+++ b/infosec-scan/py-sectest/workflow_mutex_test.py
@@ -103,48 +103,10 @@ class Test:
     assert m, f"could not parse count from run-sql output: {out}"
     return int(m.group(1))
 
-  # TEST: step-scoped lock (the "Protect with lock" checkbox + Lock name
-  # config on any step) serializes concurrent runs across two node
-  # processes sharing one database.
-  def test_step_scoped_lock_serializes_across_nodes(self):
-    prefix = 'steplock'
-    trigger_id = self._create_trigger('mutex_test_step_lock_wf')
-    self._add_step(trigger_id, {
-      'wf_step_name': 'locked_step',
-      'wf_action_name': 'run_js_code',
-      'wf_initial_step': 'on',
-      'wf_only_if': '',
-      'wf_next_step': '',
-      'mutex_enabled': 'on',
-      'mutex_lock_name': '"steplock-shared-lock"',
-      'code': log_step_code(prefix, 1500),
-      'run_where': 'Server',
-    })
-
-    results = {}
-    t1 = threading.Thread(
-      target=self._fire_testrun, args=(self.sess1, trigger_id, results, 's1')
-    )
-    t2 = threading.Thread(
-      target=self._fire_testrun, args=(self.sess2, trigger_id, results, 's2')
-    )
-    t1.start()
-    t2.start()
-    t1.join(timeout=30)
-    t2.join(timeout=30)
-
-    assert results['s1'][0] == 302, results['s1'][1]
-    assert results['s2'][0] == 302, results['s2'][1]
-
-    markers = self._markers(prefix)
-    logger.info(f"[{prefix}] marker sequence: {markers}")
-    assert markers == [
-      f'{prefix}-start', f'{prefix}-end', f'{prefix}-start', f'{prefix}-end'
-    ], f"expected serialized start,end,start,end but got {markers}"
-
-  # Without the lock, the same setup should overlap instead - proving
-  # this test can actually tell locked from unlocked.
-  def test_step_scope_without_lock_interleaves(self):
+  # Without a lock, concurrent runs should overlap - proving the markers
+  # setup can actually tell locked from unlocked (used as the baseline for
+  # the AcquireLock/ReleaseLock test below).
+  def test_without_lock_interleaves(self):
     prefix = 'nolock'
     trigger_id = self._create_trigger('mutex_test_no_lock_wf')
     self._add_step(trigger_id, {
@@ -237,20 +199,35 @@ class Test:
 
   # The first run holds the lock for 4s. The second starts 1s later with
   # a 1s timeout, so it should fail instead of waiting.
-  def test_step_scoped_lock_timeout_fails_second_run(self):
+  def test_acquire_lock_timeout_fails_second_run(self):
     prefix = 'timeoutlock'
+    lock_name = 'timeoutlock-shared-lock'
     trigger_id = self._create_trigger('mutex_test_timeout_wf')
     self._add_step(trigger_id, {
-      'wf_step_name': 'locked_step',
-      'wf_action_name': 'run_js_code',
+      'wf_step_name': 'acquire',
+      'wf_action_name': 'AcquireLock',
       'wf_initial_step': 'on',
       'wf_only_if': '',
-      'wf_next_step': '',
-      'mutex_enabled': 'on',
-      'mutex_lock_name': '"timeoutlock-shared-lock"',
-      'mutex_lock_timeout': '1',
+      'wf_next_step': 'log',
+      'lock_name': f'"{lock_name}"',
+      'lock_timeout': '1',
+    })
+    self._add_step(trigger_id, {
+      'wf_step_name': 'log',
+      'wf_action_name': 'run_js_code',
+      'wf_initial_step': '',
+      'wf_only_if': '',
+      'wf_next_step': 'release',
       'code': log_step_code(prefix, 4000),
       'run_where': 'Server',
+    })
+    self._add_step(trigger_id, {
+      'wf_step_name': 'release',
+      'wf_action_name': 'ReleaseLock',
+      'wf_initial_step': '',
+      'wf_only_if': '',
+      'wf_next_step': '',
+      'lock_name': f'"{lock_name}"',
     })
 
     results = {}
@@ -284,26 +261,3 @@ class Test:
       f"expected only the first run's start/end (the second should have "
       f"been blocked before it ran) but got {markers}"
     )
-
-  # TEST: checking "Protect with lock" without giving a Lock name should be
-  # rejected by the step editor, not saved as a silently-unlocked step.
-  def test_blank_lock_name_rejected_when_protect_with_lock_enabled(self):
-    trigger_id = self._create_trigger('mutex_test_blank_name_wf')
-    self.sess1.get(f'/actions/stepedit/{trigger_id}')
-    self.sess1.postForm(f'/actions/stepedit/{trigger_id}', {
-      'wf_step_name': 'locked_step',
-      'wf_action_name': 'run_js_code',
-      'wf_initial_step': 'on',
-      'wf_only_if': '',
-      'wf_next_step': '',
-      'mutex_enabled': 'on',
-      'mutex_lock_name': '',
-      'code': 'return {};',
-      'run_where': 'Server',
-      '_csrf': self.sess1.csrf(),
-    })
-    assert self.sess1.status != 302, (
-      "expected the step save to be rejected (blank lock name with "
-      f"Protect with lock enabled) but it redirected: {self.sess1.content}"
-    )
-    assert 'Lock name is required' in self.sess1.content, self.sess1.content

--- a/infosec-scan/py-sectest/workflow_mutex_test.py
+++ b/infosec-scan/py-sectest/workflow_mutex_test.py
@@ -284,3 +284,26 @@ class Test:
       f"expected only the first run's start/end (the second should have "
       f"been blocked before it ran) but got {markers}"
     )
+
+  # TEST: checking "Protect with lock" without giving a Lock name should be
+  # rejected by the step editor, not saved as a silently-unlocked step.
+  def test_blank_lock_name_rejected_when_protect_with_lock_enabled(self):
+    trigger_id = self._create_trigger('mutex_test_blank_name_wf')
+    self.sess1.get(f'/actions/stepedit/{trigger_id}')
+    self.sess1.postForm(f'/actions/stepedit/{trigger_id}', {
+      'wf_step_name': 'locked_step',
+      'wf_action_name': 'run_js_code',
+      'wf_initial_step': 'on',
+      'wf_only_if': '',
+      'wf_next_step': '',
+      'mutex_enabled': 'on',
+      'mutex_lock_name': '',
+      'code': 'return {};',
+      'run_where': 'Server',
+      '_csrf': self.sess1.csrf(),
+    })
+    assert self.sess1.status != 302, (
+      "expected the step save to be rejected (blank lock name with "
+      f"Protect with lock enabled) but it redirected: {self.sess1.content}"
+    )
+    assert 'Lock name is required' in self.sess1.content, self.sess1.content

--- a/infosec-scan/py-sectest/workflow_mutex_test.py
+++ b/infosec-scan/py-sectest/workflow_mutex_test.py
@@ -1,4 +1,5 @@
 import re
+import time
 import threading
 import logging
 from scsession import SaltcornSession
@@ -14,19 +15,6 @@ logger = logging.getLogger(__name__)
 email = 'admin@foo.com'
 password = 'AhGGr6rhu45'
 
-LOCK_NAME = 'mutex-test-shared-lock'
-START_MARKER = 'mutex-test-start'
-END_MARKER = 'mutex-test-end'
-
-# Logs start/end rows into "books" (reused as a scratch log) around a sleep.
-# Serialized: start,end,start,end. Interleaved (mutex failed): start,start,end,end.
-STEP_CODE = (
-  'const table = Table.findOne({name: "books"});\n'
-  f'await table.insertRow({{author: "{START_MARKER}", pages: 0}});\n'
-  'await sleep(1500);\n'
-  f'await table.insertRow({{author: "{END_MARKER}", pages: 0}});\n'
-)
-
 
 def login(sess):
   sess.get('/auth/login')
@@ -35,6 +23,17 @@ def login(sess):
     'password': password,
     '_csrf': sess.csrf(),
   })
+
+
+def log_step_code(prefix, sleep_ms):
+  # Inserts a start row, sleeps, inserts an end row into "books" (reused as
+  # a scratch log, avoiding the need to build a table over HTTP).
+  return (
+    'const table = Table.findOne({name: "books"});\n'
+    f'await table.insertRow({{author: "{prefix}-start", pages: 0}});\n'
+    f'await sleep({sleep_ms});\n'
+    f'await table.insertRow({{author: "{prefix}-end", pages: 0}});\n'
+  )
 
 
 class Test:
@@ -46,19 +45,19 @@ class Test:
     self.sess2 = SaltcornSession(port=3002, env_vars={
         "SALTCORN_MULTI_NODE": True,
     }, pipe_output=True)
+    login(self.sess1)
+    login(self.sess2)
 
   def teardown_class(self):
     self.sess1.close()
     self.sess2.close()
 
-  # Create a "Never" workflow trigger with a single run_js_code step that
-  # has a "Lock name" set (step-scoped mutex, models/mutex.ts withLock).
-  # Returns the new trigger's id.
-  def _create_locked_workflow(self):
-    logger.info("Creating workflow trigger")
+  # --- helpers ---------------------------------------------------------
+
+  def _create_trigger(self, name):
     self.sess1.get('/actions/new')
     self.sess1.postForm('/actions/new', {
-      'name': 'mutex_test_wf',
+      'name': name,
       'when_trigger': 'Never',
       'table_id': '',
       'action': 'Workflow',
@@ -69,64 +68,219 @@ class Test:
     # redirect_url looks like /actions/configure/<trigger_id>
     trigger_id = self.sess1.redirect_url.rstrip('/').split('/')[-1]
     assert trigger_id.isdigit(), self.sess1.redirect_url
+    return trigger_id
 
-    logger.info(f"Adding locked step to trigger {trigger_id}")
+  def _add_step(self, trigger_id, fields):
     self.sess1.get(f'/actions/stepedit/{trigger_id}')
-    self.sess1.postForm(f'/actions/stepedit/{trigger_id}', {
+    fields = dict(fields)
+    fields['_csrf'] = self.sess1.csrf()
+    self.sess1.postForm(f'/actions/stepedit/{trigger_id}', fields)
+    assert self.sess1.status == 302, self.sess1.content
+
+  def _fire_testrun(self, sess, trigger_id, results, key):
+    sess.get(f'/actions/testrun/{trigger_id}')
+    results[key] = (sess.status, sess.content)
+
+  def _markers(self, prefix):
+    out = SaltcornSession.cli(
+      "run-sql",
+      "--sql",
+      f"select author from books where author like '{prefix}-%' order by id",
+    )
+    return re.findall(rf"'({re.escape(prefix)}-(?:start|end))'", out)
+
+  # testrun always redirects (302), even if a step failed, so check the
+  # run's stored status instead of the HTTP response.
+  def _error_run_count(self, trigger_id, message_substring):
+    out = SaltcornSession.cli(
+      "run-sql",
+      "--sql",
+      "select 'COUNT_RESULT:' || count(*) as result from _sc_workflow_runs "
+      f"where trigger_id = {trigger_id} and status = 'Error' "
+      f"and error like '%{message_substring}%'",
+    )
+    m = re.search(r"COUNT_RESULT:(\d+)", out)
+    assert m, f"could not parse count from run-sql output: {out}"
+    return int(m.group(1))
+
+  # TEST: step-scoped lock (the "Protect with lock" checkbox + Lock name
+  # config on any step) serializes concurrent runs across two node
+  # processes sharing one database.
+  def test_step_scoped_lock_serializes_across_nodes(self):
+    prefix = 'steplock'
+    trigger_id = self._create_trigger('mutex_test_step_lock_wf')
+    self._add_step(trigger_id, {
       'wf_step_name': 'locked_step',
       'wf_action_name': 'run_js_code',
       'wf_initial_step': 'on',
       'wf_only_if': '',
       'wf_next_step': '',
       'mutex_enabled': 'on',
-      'mutex_lock_name': f'"{LOCK_NAME}"',
-      'code': STEP_CODE,
+      'mutex_lock_name': '"steplock-shared-lock"',
+      'code': log_step_code(prefix, 1500),
       'run_where': 'Server',
-      '_csrf': self.sess1.csrf(),
     })
-    assert self.sess1.status == 302, self.sess1.content
-
-    return trigger_id
-
-  def _run_count(self):
-    out = SaltcornSession.cli(
-      "run-sql",
-      "--sql",
-      f"select author from books where author like 'mutex-test-%' order by id",
-    )
-    return re.findall(r"'(mutex-test-(?:start|end))'", out)
-
-  # TEST:
-  # fire the same locked workflow concurrently from two separate node
-  # processes (sharing one database) and check that their critical
-  # sections did not interleave.
-  def test_step_scoped_lock_serializes_across_nodes(self):
-    logger.info("sess1 and sess2 logging in")
-    login(self.sess1)
-    login(self.sess2)
-
-    trigger_id = self._create_locked_workflow()
 
     results = {}
-
-    def fire(sess, key):
-      sess.get(f'/actions/testrun/{trigger_id}')
-      results[key] = sess.status
-
-    t1 = threading.Thread(target=fire, args=(self.sess1, 'sess1'))
-    t2 = threading.Thread(target=fire, args=(self.sess2, 'sess2'))
+    t1 = threading.Thread(
+      target=self._fire_testrun, args=(self.sess1, trigger_id, results, 's1')
+    )
+    t2 = threading.Thread(
+      target=self._fire_testrun, args=(self.sess2, trigger_id, results, 's2')
+    )
     t1.start()
     t2.start()
     t1.join(timeout=30)
     t2.join(timeout=30)
 
-    assert results.get('sess1') == 302, self.sess1.content
-    assert results.get('sess2') == 302, self.sess2.content
+    assert results['s1'][0] == 302, results['s1'][1]
+    assert results['s2'][0] == 302, results['s2'][1]
 
-    markers = self._run_count()
-    logger.info(f"Observed marker sequence: {markers}")
-    assert len(markers) == 4, markers
-    assert markers == [START_MARKER, END_MARKER, START_MARKER, END_MARKER], (
-      f"expected serialized start,end,start,end but got {markers} - "
-      "this would mean the two nodes' locked steps interleaved"
+    markers = self._markers(prefix)
+    logger.info(f"[{prefix}] marker sequence: {markers}")
+    assert markers == [
+      f'{prefix}-start', f'{prefix}-end', f'{prefix}-start', f'{prefix}-end'
+    ], f"expected serialized start,end,start,end but got {markers}"
+
+  # Without the lock, the same setup should overlap instead - proving
+  # this test can actually tell locked from unlocked.
+  def test_step_scope_without_lock_interleaves(self):
+    prefix = 'nolock'
+    trigger_id = self._create_trigger('mutex_test_no_lock_wf')
+    self._add_step(trigger_id, {
+      'wf_step_name': 'unlocked_step',
+      'wf_action_name': 'run_js_code',
+      'wf_initial_step': 'on',
+      'wf_only_if': '',
+      'wf_next_step': '',
+      'code': log_step_code(prefix, 1500),
+      'run_where': 'Server',
+    })
+
+    results = {}
+    t1 = threading.Thread(
+      target=self._fire_testrun, args=(self.sess1, trigger_id, results, 's1')
+    )
+    t2 = threading.Thread(
+      target=self._fire_testrun, args=(self.sess2, trigger_id, results, 's2')
+    )
+    t1.start()
+    t2.start()
+    t1.join(timeout=30)
+    t2.join(timeout=30)
+
+    assert results['s1'][0] == 302, results['s1'][1]
+    assert results['s2'][0] == 302, results['s2'][1]
+
+    markers = self._markers(prefix)
+    logger.info(f"[{prefix}] marker sequence: {markers}")
+    assert markers == [
+      f'{prefix}-start', f'{prefix}-start', f'{prefix}-end', f'{prefix}-end'
+    ], (
+      f"expected interleaved start,start,end,end (no lock) but got {markers} "
+      "- if this is serialized, something other than the mutex feature is "
+      "serializing these requests, which would undermine the positive test above"
+    )
+
+  # TEST: run-scoped lock (AcquireLock ... ReleaseLock step pair) held
+  # across an intervening step, serializing concurrent runs.
+  def test_run_scoped_acquire_release_serializes_across_nodes(self):
+    prefix = 'runlock'
+    lock_name = 'runlock-shared-lock'
+    trigger_id = self._create_trigger('mutex_test_run_scope_wf')
+    self._add_step(trigger_id, {
+      'wf_step_name': 'acquire',
+      'wf_action_name': 'AcquireLock',
+      'wf_initial_step': 'on',
+      'wf_only_if': '',
+      'wf_next_step': 'log',
+      'lock_name': f'"{lock_name}"',
+    })
+    self._add_step(trigger_id, {
+      'wf_step_name': 'log',
+      'wf_action_name': 'run_js_code',
+      'wf_initial_step': '',
+      'wf_only_if': '',
+      'wf_next_step': 'release',
+      'code': log_step_code(prefix, 1500),
+      'run_where': 'Server',
+    })
+    self._add_step(trigger_id, {
+      'wf_step_name': 'release',
+      'wf_action_name': 'ReleaseLock',
+      'wf_initial_step': '',
+      'wf_only_if': '',
+      'wf_next_step': '',
+      'lock_name': f'"{lock_name}"',
+    })
+
+    results = {}
+    t1 = threading.Thread(
+      target=self._fire_testrun, args=(self.sess1, trigger_id, results, 's1')
+    )
+    t2 = threading.Thread(
+      target=self._fire_testrun, args=(self.sess2, trigger_id, results, 's2')
+    )
+    t1.start()
+    t2.start()
+    t1.join(timeout=30)
+    t2.join(timeout=30)
+
+    assert results['s1'][0] == 302, results['s1'][1]
+    assert results['s2'][0] == 302, results['s2'][1]
+
+    markers = self._markers(prefix)
+    logger.info(f"[{prefix}] marker sequence: {markers}")
+    assert markers == [
+      f'{prefix}-start', f'{prefix}-end', f'{prefix}-start', f'{prefix}-end'
+    ], f"expected serialized start,end,start,end but got {markers}"
+
+  # The first run holds the lock for 4s. The second starts 1s later with
+  # a 1s timeout, so it should fail instead of waiting.
+  def test_step_scoped_lock_timeout_fails_second_run(self):
+    prefix = 'timeoutlock'
+    trigger_id = self._create_trigger('mutex_test_timeout_wf')
+    self._add_step(trigger_id, {
+      'wf_step_name': 'locked_step',
+      'wf_action_name': 'run_js_code',
+      'wf_initial_step': 'on',
+      'wf_only_if': '',
+      'wf_next_step': '',
+      'mutex_enabled': 'on',
+      'mutex_lock_name': '"timeoutlock-shared-lock"',
+      'mutex_lock_timeout': '1',
+      'code': log_step_code(prefix, 4000),
+      'run_where': 'Server',
+    })
+
+    results = {}
+    t1 = threading.Thread(
+      target=self._fire_testrun, args=(self.sess1, trigger_id, results, 'first')
+    )
+    t1.start()
+    time.sleep(1)  # let the first run acquire the lock and start its 4s sleep
+    t2 = threading.Thread(
+      target=self._fire_testrun, args=(self.sess2, trigger_id, results, 'second')
+    )
+    t2.start()
+    t1.join(timeout=30)
+    t2.join(timeout=30)
+
+    # both requests redirect (302) regardless of outcome - the workflow
+    # engine swallows the second run's step error internally rather than
+    # raising it through the route, so check its stored status instead
+    assert results['first'][0] == 302, results['first'][1]
+    assert results['second'][0] == 302, results['second'][1]
+
+    error_count = self._error_run_count(trigger_id, 'lock timeout')
+    assert error_count == 1, (
+      f"expected exactly one run of trigger {trigger_id} to have errored "
+      f"with a lock timeout, found {error_count}"
+    )
+
+    markers = self._markers(prefix)
+    logger.info(f"[{prefix}] marker sequence: {markers}")
+    assert markers == [f'{prefix}-start', f'{prefix}-end'], (
+      f"expected only the first run's start/end (the second should have "
+      f"been blocked before it ran) but got {markers}"
     )

--- a/packages/saltcorn-data/base-plugin/actions.ts
+++ b/packages/saltcorn-data/base-plugin/actions.ts
@@ -22,6 +22,7 @@ import {
 } from "../models/expression.js";
 import {
   sleep,
+  withLock,
   getSessionId,
   urlStringToObject,
   dollarizeObject,
@@ -268,6 +269,11 @@ const run_code = async ({
     ...(isNode() ? { assert } : {}),
     tryCatchInTransaction: db.tryCatchInTransaction,
     commitAndBeginNewTransaction: db.commitAndBeginNewTransaction,
+    withLock: (
+      name: string,
+      fn: () => Promise<any>,
+      opts?: { timeoutMs?: number }
+    ) => withLock(name, fn, opts),
     commitBeginNewTransactionAndRefreshCache: async () => {
       await db.commitAndBeginNewTransaction();
       await sysState.refresh();

--- a/packages/saltcorn-data/models/multi_node_mutex.ts
+++ b/packages/saltcorn-data/models/multi_node_mutex.ts
@@ -21,14 +21,35 @@ export const DEFAULT_TIMEOUT_MS = 30_000;
 
 // SQLite fallback
 const localLocksHeld: Set<string> = new Set();
-const localLockWaiters: Map<string, Array<() => void>> = new Map();
+const localLockWaiters: Map<string, Array<{ resolve: () => void }>> = new Map();
 
-const acquireLockLocally = async (name: string): Promise<void> => {
+// timeoutMs === 0 means wait forever, same as the Postgres path
+const acquireLockLocally = async (
+  name: string,
+  timeoutMs: number
+): Promise<void> => {
   while (localLocksHeld.has(name)) {
-    await new Promise<void>((resolve) => {
+    await new Promise<void>((resolve, reject) => {
+      let timer: NodeJS.Timeout | undefined;
+      const waiter = {
+        resolve: () => {
+          if (timer) clearTimeout(timer);
+          resolve();
+        },
+      };
       const waiters = localLockWaiters.get(name) || [];
-      waiters.push(resolve);
+      waiters.push(waiter);
       localLockWaiters.set(name, waiters);
+      if (timeoutMs > 0) {
+        timer = setTimeout(() => {
+          const current = localLockWaiters.get(name);
+          const idx = current?.indexOf(waiter) ?? -1;
+          if (idx !== -1) {
+            current!.splice(idx, 1);
+            reject(new Error(`lock timeout waiting for "${name}"`));
+          }
+        }, timeoutMs);
+      }
     });
   }
   localLocksHeld.add(name);
@@ -37,7 +58,7 @@ const acquireLockLocally = async (name: string): Promise<void> => {
 const releaseLockLocally = (name: string): void => {
   localLocksHeld.delete(name);
   const next = localLockWaiters.get(name)?.shift();
-  if (next) next();
+  if (next) next.resolve();
 };
 
 // Clear lock_timeout before returning this connection to the pool, so it
@@ -72,12 +93,6 @@ export class MultiNodeMutex {
     opts: { timeoutMs?: number } = {}
   ): Promise<void> {
     if (this.lockConnections.has(name)) return;
-    if (db.driverName !== "postgres") {
-      await acquireLockLocally(name);
-      this.lockConnections.set(name, true);
-      return;
-    }
-    const client = await db.getClient();
     // not given at all -> bounded default; explicitly 0 -> wait forever
     const timeoutMs =
       opts.timeoutMs === undefined ||
@@ -85,6 +100,12 @@ export class MultiNodeMutex {
       opts.timeoutMs < 0
         ? DEFAULT_TIMEOUT_MS
         : Math.floor(opts.timeoutMs);
+    if (db.driverName !== "postgres") {
+      await acquireLockLocally(name, timeoutMs);
+      this.lockConnections.set(name, true);
+      return;
+    }
+    const client = await db.getClient();
     try {
       await client.query("select set_config('lock_timeout', $1, false)", [
         String(timeoutMs),

--- a/packages/saltcorn-data/models/multi_node_mutex.ts
+++ b/packages/saltcorn-data/models/multi_node_mutex.ts
@@ -17,6 +17,8 @@ import db from "../db/index.js";
 // (serve.js, id 11565) so the two can't collide.
 const MUTEX_CLASSID = 894213;
 
+export const DEFAULT_TIMEOUT_MS = 30_000;
+
 // SQLite fallback
 const localLocksHeld: Set<string> = new Set();
 const localLockWaiters: Map<string, Array<() => void>> = new Map();
@@ -38,6 +40,17 @@ const releaseLockLocally = (name: string): void => {
   if (next) next();
 };
 
+// Clear lock_timeout before returning this connection to the pool, so it
+// doesn't affect whoever reuses it next. Discard it instead if that fails.
+const releaseClient = async (client: any): Promise<void> => {
+  try {
+    await client.query("RESET lock_timeout");
+    client.release();
+  } catch (e) {
+    client.release(true);
+  }
+};
+
 /**
  * A named lock that stays held until you release it, e.g. one workflow run
  * holding a lock across several steps. For a single critical section, use
@@ -51,8 +64,8 @@ export class MultiNodeMutex {
    * called. Re-entrant: acquiring a name already held by this
    * MultiNodeMutex is a no-op.
    *
-   * @param opts.timeoutMs - throw instead of waiting indefinitely if the
-   *   lock isn't acquired within this many milliseconds
+   * @param opts.timeoutMs - throw if the lock isn't acquired within this
+   *   many milliseconds. Defaults to DEFAULT_TIMEOUT_MS if not given.
    */
   async acquire(
     name: string,
@@ -65,18 +78,23 @@ export class MultiNodeMutex {
       return;
     }
     const client = await db.getClient();
+    // not given at all -> bounded default; explicitly 0 -> wait forever
     const timeoutMs =
-      opts.timeoutMs && Number.isFinite(opts.timeoutMs) && opts.timeoutMs > 0
-        ? Math.floor(opts.timeoutMs)
-        : 0; // 0 = wait indefinitely
+      opts.timeoutMs === undefined ||
+      !Number.isFinite(opts.timeoutMs) ||
+      opts.timeoutMs < 0
+        ? DEFAULT_TIMEOUT_MS
+        : Math.floor(opts.timeoutMs);
     try {
-      await client.query(`SET lock_timeout = '${timeoutMs}ms'`);
+      await client.query("select set_config('lock_timeout', $1, false)", [
+        String(timeoutMs),
+      ]);
       await client.query("select pg_advisory_lock($1, hashtext($2))", [
         MUTEX_CLASSID,
         name,
       ]);
     } catch (e) {
-      client.release();
+      await releaseClient(client);
       throw e;
     }
     this.lockConnections.set(name, client);
@@ -97,18 +115,28 @@ export class MultiNodeMutex {
         name,
       ]);
     } finally {
-      client.release();
+      await releaseClient(client);
     }
   }
 
   /**
    * Release every lock still held. Call in a finally block around a run's
    * execution so an error, finish, or pause never leaves a lock - and its
-   * dedicated connection - stuck open.
+   * dedicated connection - stuck open. One lock failing to release doesn't
+   * stop the rest from being attempted; any failures are thrown together
+   * once all locks have been tried.
    */
   async releaseAll(): Promise<void> {
-    for (const name of [...this.lockConnections.keys()])
-      await this.release(name);
+    const errors: unknown[] = [];
+    for (const name of [...this.lockConnections.keys()]) {
+      try {
+        await this.release(name);
+      } catch (e) {
+        errors.push(e);
+      }
+    }
+    if (errors.length)
+      throw new AggregateError(errors, "Failed to release one or more locks");
   }
 
   /**

--- a/packages/saltcorn-data/models/multi_node_mutex.ts
+++ b/packages/saltcorn-data/models/multi_node_mutex.ts
@@ -1,0 +1,134 @@
+/**
+ * Cross-node mutex, used by workflow steps and (via utils.ts's withLock)
+ * run_js_code.
+ *
+ * Postgres: backed by advisory locks, held on a dedicated connection so the
+ * lock's lifetime is just "acquired until released" - not tied to any
+ * transaction. SQLite (always single-node): backed by an in-process
+ * fallback.
+ *
+ * @category saltcorn-data
+ * @module models/multi_node_mutex
+ * @subcategory models
+ */
+import db from "../db/index.js";
+
+// Own advisory-lock namespace, kept separate from the leader-election lock
+// (serve.js, id 11565) so the two can't collide.
+const MUTEX_CLASSID = 894213;
+
+// SQLite fallback
+const localLocksHeld: Set<string> = new Set();
+const localLockWaiters: Map<string, Array<() => void>> = new Map();
+
+const acquireLockLocally = async (name: string): Promise<void> => {
+  while (localLocksHeld.has(name)) {
+    await new Promise<void>((resolve) => {
+      const waiters = localLockWaiters.get(name) || [];
+      waiters.push(resolve);
+      localLockWaiters.set(name, waiters);
+    });
+  }
+  localLocksHeld.add(name);
+};
+
+const releaseLockLocally = (name: string): void => {
+  localLocksHeld.delete(name);
+  const next = localLockWaiters.get(name)?.shift();
+  if (next) next();
+};
+
+/**
+ * A named lock that stays held until you release it, e.g. one workflow run
+ * holding a lock across several steps. For a single critical section, use
+ * the withLock() helper below instead.
+ */
+export class MultiNodeMutex {
+  private lockConnections: Map<string, any> = new Map();
+
+  /**
+   * Acquire a lock that stays held until release() (or releaseAll()) is
+   * called. Re-entrant: acquiring a name already held by this
+   * MultiNodeMutex is a no-op.
+   *
+   * @param opts.timeoutMs - throw instead of waiting indefinitely if the
+   *   lock isn't acquired within this many milliseconds
+   */
+  async acquire(
+    name: string,
+    opts: { timeoutMs?: number } = {}
+  ): Promise<void> {
+    if (this.lockConnections.has(name)) return;
+    if (db.driverName !== "postgres") {
+      await acquireLockLocally(name);
+      this.lockConnections.set(name, true);
+      return;
+    }
+    const client = await db.getClient();
+    const timeoutMs =
+      opts.timeoutMs && Number.isFinite(opts.timeoutMs) && opts.timeoutMs > 0
+        ? Math.floor(opts.timeoutMs)
+        : 0; // 0 = wait indefinitely
+    try {
+      await client.query(`SET lock_timeout = '${timeoutMs}ms'`);
+      await client.query("select pg_advisory_lock($1, hashtext($2))", [
+        MUTEX_CLASSID,
+        name,
+      ]);
+    } catch (e) {
+      client.release();
+      throw e;
+    }
+    this.lockConnections.set(name, client);
+  }
+
+  /** Release a lock acquired with acquire(). No-op if not held. */
+  async release(name: string): Promise<void> {
+    const client = this.lockConnections.get(name);
+    if (client === undefined) return;
+    this.lockConnections.delete(name);
+    if (db.driverName !== "postgres") {
+      releaseLockLocally(name);
+      return;
+    }
+    try {
+      await client.query("select pg_advisory_unlock($1, hashtext($2))", [
+        MUTEX_CLASSID,
+        name,
+      ]);
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Release every lock still held. Call in a finally block around a run's
+   * execution so an error, finish, or pause never leaves a lock - and its
+   * dedicated connection - stuck open.
+   */
+  async releaseAll(): Promise<void> {
+    for (const name of [...this.lockConnections.keys()])
+      await this.release(name);
+  }
+
+  /**
+   * Run fn() while holding an exclusive lock named `name`, released as soon
+   * as fn() returns or throws.
+   *
+   * @param name - lock name; shared names are mutually exclusive across nodes
+   * @param fn - critical section to run while the lock is held
+   * @param opts.timeoutMs - see acquire()
+   */
+  async withLock<T>(
+    name: string,
+    fn: () => Promise<T>,
+    opts: { timeoutMs?: number } = {}
+  ): Promise<T> {
+    await this.acquire(name, opts);
+    try {
+      return await fn();
+    } finally {
+      await this.release(name);
+    }
+  }
+}

--- a/packages/saltcorn-data/models/workflow_run.ts
+++ b/packages/saltcorn-data/models/workflow_run.ts
@@ -425,11 +425,28 @@ class WorkflowRun {
     trace?: boolean;
     req?: any;
   }) {
+    let result: any;
+    let runError: unknown;
+    let hasRunError = false;
     try {
-      return await this.runInner(args);
-    } finally {
-      await this.mutex.releaseAll();
+      result = await this.runInner(args);
+    } catch (e) {
+      runError = e;
+      hasRunError = true;
     }
+    try {
+      await this.mutex.releaseAll();
+    } catch (releaseErr) {
+      // don't let a lock-release failure hide the real run error - just log it
+      if (hasRunError)
+        console.error(
+          "Error releasing locks after workflow run error",
+          releaseErr
+        );
+      else throw releaseErr;
+    }
+    if (hasRunError) throw runError;
+    return result;
   }
 
   private async runInner({

--- a/packages/saltcorn-data/models/workflow_run.ts
+++ b/packages/saltcorn-data/models/workflow_run.ts
@@ -72,9 +72,8 @@ class WorkflowRun {
 
   step_start?: Date;
 
-  // holds locks acquired by an AcquireLock step until released or the run
-  // ends/pauses (see models/mutex.ts); excluded from toJson below, it isn't
-  // a real column
+  // Holds locks acquired by an AcquireLock step (see models/multi_node_mutex.ts).
+  // Excluded from toJson below since it isn't a real column.
   mutex: MultiNodeMutex = new MultiNodeMutex();
 
   /**

--- a/packages/saltcorn-data/models/workflow_run.ts
+++ b/packages/saltcorn-data/models/workflow_run.ts
@@ -27,6 +27,7 @@ import {
 } from "../utils.js";
 import { eval_expression } from "./expression.js";
 import { AbstractUser } from "@saltcorn/types/model-abstracts/abstract_user";
+import { MultiNodeMutex } from "./multi_node_mutex.js";
 
 const data_output_to_html = (val: any) => {
   if (Array.isArray(val) && typeof val[0] === "object") {
@@ -71,6 +72,11 @@ class WorkflowRun {
 
   step_start?: Date;
 
+  // holds locks acquired by an AcquireLock step until released or the run
+  // ends/pauses (see models/mutex.ts); excluded from toJson below, it isn't
+  // a real column
+  mutex: MultiNodeMutex = new MultiNodeMutex();
+
   /**
    * WorkflowRun constructor
    * @param {object} o
@@ -111,7 +117,7 @@ class WorkflowRun {
    * @type {...*}
    */
   get toJson(): any {
-    const { id, steps, step_start, ...rest } = this;
+    const { id, steps, step_start, mutex, ...rest } = this;
     return rest;
   }
 
@@ -411,7 +417,22 @@ class WorkflowRun {
     this.current_step[Math.max(0, this.current_step.length - 1)] = stepName;
   }
 
-  async run({
+  async run(args: {
+    user?: AbstractUser;
+    interactive?: boolean;
+    noNotifications?: boolean;
+    api_call?: boolean;
+    trace?: boolean;
+    req?: any;
+  }) {
+    try {
+      return await this.runInner(args);
+    } finally {
+      await this.mutex.releaseAll();
+    }
+  }
+
+  private async runInner({
     user,
     interactive,
     noNotifications,
@@ -833,7 +854,7 @@ class WorkflowRun {
           } else if (waiting_fulfilled) {
             waiting_fulfilled = false;
           } else if (step && user)
-            result = await step.run(this.context, user, req);
+            result = await step.run(this.context, user, req, this);
 
           const nextUpdate: any = {};
           if (typeof result === "object" && result !== null) {

--- a/packages/saltcorn-data/models/workflow_step.ts
+++ b/packages/saltcorn-data/models/workflow_step.ts
@@ -4,7 +4,7 @@
  * @module models/workflow_step
  * @subcategory models
  */
-import { jsIdentifierValidator } from "../utils.js";
+import { jsIdentifierValidator, withLock } from "../utils.js";
 import { getState } from "../db/state.js";
 import db from "../db/index.js";
 import type { Where, SelectOptions, Row } from "@saltcorn/db-common/internal";
@@ -208,7 +208,7 @@ class WorkflowStep {
     await db.update("_sc_workflow_steps", row, this.id);
   }
 
-  async run(context: any, user: AbstractUser, req?: any) {
+  async run(context: any, user: AbstractUser, req?: any, workflowRun?: any) {
     if (this.only_if) {
       const proceed = eval_expression(
         this.only_if,
@@ -219,6 +219,51 @@ class WorkflowStep {
       if (!proceed) return;
     }
 
+    if (
+      this.action_name === "AcquireLock" ||
+      this.action_name === "ReleaseLock"
+    ) {
+      if (!workflowRun)
+        throw new Error(`${this.action_name} step requires a workflow run`);
+      const lockName = eval_expression(
+        this.configuration.lock_name,
+        context,
+        user,
+        `Lock name expression in ${this.name} step`
+      );
+      if (this.action_name === "AcquireLock") {
+        const timeoutSecs = this.configuration.lock_timeout;
+        await workflowRun.mutex.acquire(String(lockName), {
+          timeoutMs:
+            typeof timeoutSecs === "number" ? timeoutSecs * 1000 : undefined,
+        });
+      } else {
+        await workflowRun.mutex.release(String(lockName));
+      }
+      return;
+    }
+
+    if (this.configuration?.mutex_enabled && this.configuration?.mutex_lock_name) {
+      const lockName = eval_expression(
+        this.configuration.mutex_lock_name,
+        context,
+        user,
+        `Lock name expression in ${this.name} step`
+      );
+      const timeoutSecs = this.configuration.mutex_lock_timeout;
+      return await withLock(
+        String(lockName),
+        () => this.runAction(context, user, req),
+        {
+          timeoutMs:
+            typeof timeoutSecs === "number" ? timeoutSecs * 1000 : undefined,
+        }
+      );
+    }
+    return await this.runAction(context, user, req);
+  }
+
+  private async runAction(context: any, user: AbstractUser, req?: any) {
     if (this.action_name === "TableQuery") {
       const table = Table.findOne({ name: this.configuration.query_table });
       if (!table)
@@ -461,6 +506,11 @@ class WorkflowStep {
         if (cfg.error_handling_step)
           lines.push(`${t("Error handler")}: ${cfg.error_handling_step}`);
         break;
+      case "AcquireLock":
+      case "ReleaseLock":
+        if (cfg.lock_name)
+          lines.push(`${t("Lock name")}: ${shorten(cfg.lock_name)}`);
+        break;
       case "Output":
         if (cfg.popup_title) lines.push(`${t("Title")}: ${cfg.popup_title}`);
         // if (cfg.output_text) lines.push(shorten(cfg.output_text, 180));
@@ -568,6 +618,10 @@ class WorkflowStep {
       "Ask the user to fill in a form from an Edit view, storing the response in the context";
     actionExplainers.TerminateWorkflow =
       "Terminate the entire workflow run execution immediately";
+    actionExplainers.AcquireLock =
+      "Wait for and hold an exclusive lock, so that no other run of any workflow holding the same named lock can proceed until it is released. Held across subsequent steps until a matching Release lock step, or until the run ends or pauses.";
+    actionExplainers.ReleaseLock =
+      "Release a lock acquired by an earlier Acquire lock step in this run";
     if (opts?.api_call)
       actionExplainers.APIResponse = "Provide the response to an API call";
 
@@ -807,6 +861,25 @@ class WorkflowStep {
       required: true,
       validator: jsIdentifierValidator,
       showIf: { wf_action_name: "TableQuery" },
+    });
+    actionConfigFields.push({
+      label: "Lock name",
+      name: "lock_name",
+      sublabel:
+        "Name of the lock. Can be a JavaScript expression based on the run context, e.g. " +
+        '<code>"invoice-"+customer_id</code>. Runs sharing the same lock name across all nodes are mutually exclusive.',
+      type: "String",
+      required: true,
+      class: "validate-expression",
+      showIf: { wf_action_name: ["AcquireLock", "ReleaseLock"] },
+    });
+    actionConfigFields.push({
+      label: "Lock timeout (s)",
+      name: "lock_timeout",
+      sublabel:
+        "Optional. If the lock is not acquired within this many seconds, the step fails instead of waiting indefinitely.",
+      type: "Float",
+      showIf: { wf_action_name: "AcquireLock" },
     });
     actionConfigFields.push({
       label: "Popup title",

--- a/packages/saltcorn-data/models/workflow_step.ts
+++ b/packages/saltcorn-data/models/workflow_step.ts
@@ -877,7 +877,7 @@ class WorkflowStep {
       label: "Lock timeout (s)",
       name: "lock_timeout",
       sublabel:
-        "Optional. If the lock is not acquired within this many seconds, the step fails instead of waiting indefinitely.",
+        "Optional. If the lock is not acquired within this many seconds, the step fails instead of waiting. Leave blank for a default 30s wait, or set to 0 to wait forever.",
       type: "Float",
       showIf: { wf_action_name: "AcquireLock" },
     });

--- a/packages/saltcorn-data/models/workflow_step.ts
+++ b/packages/saltcorn-data/models/workflow_step.ts
@@ -4,7 +4,7 @@
  * @module models/workflow_step
  * @subcategory models
  */
-import { jsIdentifierValidator, withLock } from "../utils.js";
+import { jsIdentifierValidator } from "../utils.js";
 import { getState } from "../db/state.js";
 import db from "../db/index.js";
 import type { Where, SelectOptions, Row } from "@saltcorn/db-common/internal";
@@ -243,23 +243,6 @@ class WorkflowStep {
       return;
     }
 
-    if (this.configuration?.mutex_enabled && this.configuration?.mutex_lock_name) {
-      const lockName = eval_expression(
-        this.configuration.mutex_lock_name,
-        context,
-        user,
-        `Lock name expression in ${this.name} step`
-      );
-      const timeoutSecs = this.configuration.mutex_lock_timeout;
-      return await withLock(
-        String(lockName),
-        () => this.runAction(context, user, req),
-        {
-          timeoutMs:
-            typeof timeoutSecs === "number" ? timeoutSecs * 1000 : undefined,
-        }
-      );
-    }
     return await this.runAction(context, user, req);
   }
 

--- a/packages/saltcorn-data/models/workflow_step.ts
+++ b/packages/saltcorn-data/models/workflow_step.ts
@@ -866,8 +866,10 @@ class WorkflowStep {
       label: "Lock name",
       name: "lock_name",
       sublabel:
-        "Name of the lock. Can be a JavaScript expression based on the run context, e.g. " +
-        '<code>"invoice-"+customer_id</code>. Runs sharing the same lock name across all nodes are mutually exclusive.',
+        "JavaScript expression, e.g. " +
+        '<code>"mylock"</code> for a fixed name, or ' +
+        '<code>"invoice-"+customer_id</code> using a variable. Runs sharing ' +
+        "the same lock name across all nodes are mutually exclusive.",
       type: "String",
       required: true,
       class: "validate-expression",

--- a/packages/saltcorn-data/tests/multi_node_mutex.test.ts
+++ b/packages/saltcorn-data/tests/multi_node_mutex.test.ts
@@ -1,0 +1,65 @@
+import {
+  MultiNodeMutex,
+  DEFAULT_TIMEOUT_MS,
+} from "../models/multi_node_mutex.js";
+import db from "../db/index.js";
+import {
+  afterAll,
+  describe,
+  it,
+  expect,
+  beforeAll,
+  jest,
+} from "@saltcorn/db-common/test_expect";
+import resetSchemaMod from "../db/reset_schema.js";
+import fixturesMod from "../db/fixtures.js";
+import { sleep } from "../utils.js";
+
+afterAll(db.close);
+beforeAll(async () => {
+  await resetSchemaMod();
+  await fixturesMod();
+});
+
+jest.setTimeout(10000);
+
+describe("MultiNodeMutex timeouts", () => {
+  it("has a 30s default timeout", () => {
+    expect(DEFAULT_TIMEOUT_MS).toBe(30000);
+  });
+
+  it("fails with an explicit short timeout while another instance holds the lock", async () => {
+    const holder = new MultiNodeMutex();
+    await holder.acquire("test-timeout-short");
+    try {
+      const waiter = new MultiNodeMutex();
+      let err: any = null;
+      try {
+        await waiter.acquire("test-timeout-short", { timeoutMs: 200 });
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeTruthy();
+      expect(String(err?.message || err)).toMatch(/lock timeout/i);
+    } finally {
+      await holder.release("test-timeout-short");
+    }
+  });
+
+  // The holder releases after 500ms - long enough that the 200ms case
+  // above would already have failed - proving timeoutMs: 0 genuinely
+  // waits it out instead of also failing fast.
+  it("timeoutMs: 0 waits for the lock instead of failing fast", async () => {
+    const holder = new MultiNodeMutex();
+    await holder.acquire("test-timeout-zero");
+
+    const waiter = new MultiNodeMutex();
+    const waitPromise = waiter.acquire("test-timeout-zero", { timeoutMs: 0 });
+
+    await sleep(500);
+    await holder.release("test-timeout-zero");
+
+    await waitPromise;
+    await waiter.release("test-timeout-zero");
+  });
+});

--- a/packages/saltcorn-data/tests/workflow_run.test.ts
+++ b/packages/saltcorn-data/tests/workflow_run.test.ts
@@ -1007,39 +1007,6 @@ describe("Workflow mutex", () => {
     return {};
   `;
 
-  it("step-scoped lock keeps concurrent runs from overlapping", async () => {
-    const user = await User.findOne({ id: 1 });
-    assertIsSet(user);
-    const trigger = await Trigger.create({
-      action: "Workflow",
-      when_trigger: "Never",
-      name: "mutex_steplock_wf",
-    });
-    await WorkflowStep.create({
-      trigger_id: trigger.id!,
-      name: "locked_step",
-      action_name: "run_js_code",
-      initial_step: true,
-      configuration: {
-        mutex_enabled: true,
-        mutex_lock_name: `"ts-steplock"`,
-        code: logStepCode("steplock", 300),
-        run_where: "Server",
-      },
-    });
-
-    const run1 = await WorkflowRun.create({ trigger_id: trigger.id! });
-    const run2 = await WorkflowRun.create({ trigger_id: trigger.id! });
-    await Promise.all([run1.run({ user }), run2.run({ user })]);
-
-    expect(await markers("steplock")).toStrictEqual([
-      "start",
-      "end",
-      "start",
-      "end",
-    ]);
-  });
-
   // Without the lock, the same setup should overlap instead - proving
   // this test can actually tell locked from unlocked.
   it("without the lock, concurrent runs interleave", async () => {
@@ -1132,16 +1099,32 @@ describe("Workflow mutex", () => {
     });
     await WorkflowStep.create({
       trigger_id: trigger.id!,
-      name: "locked_step",
-      action_name: "run_js_code",
+      name: "acquire",
+      action_name: "AcquireLock",
+      next_step: "log",
       initial_step: true,
       configuration: {
-        mutex_enabled: true,
-        mutex_lock_name: `"ts-timeoutlock"`,
-        mutex_lock_timeout: 0.3,
+        lock_name: `"ts-timeoutlock"`,
+        lock_timeout: 0.3,
+      },
+    });
+    await WorkflowStep.create({
+      trigger_id: trigger.id!,
+      name: "log",
+      action_name: "run_js_code",
+      next_step: "release",
+      initial_step: false,
+      configuration: {
         code: logStepCode("timeoutlock", 1000),
         run_where: "Server",
       },
+    });
+    await WorkflowStep.create({
+      trigger_id: trigger.id!,
+      name: "release",
+      action_name: "ReleaseLock",
+      initial_step: false,
+      configuration: { lock_name: `"ts-timeoutlock"` },
     });
 
     const run1 = await WorkflowRun.create({ trigger_id: trigger.id! });

--- a/packages/saltcorn-data/tests/workflow_run.test.ts
+++ b/packages/saltcorn-data/tests/workflow_run.test.ts
@@ -6,7 +6,14 @@ import Trigger from "../models/trigger.js";
 
 import db from "../db/index.js";
 import { assertIsSet } from "./assertions.js";
-import { afterAll, describe, it, expect, beforeAll, jest } from "@saltcorn/db-common/test_expect";
+import {
+  afterAll,
+  describe,
+  it,
+  expect,
+  beforeAll,
+  jest,
+} from "@saltcorn/db-common/test_expect";
 import { GenObj } from "@saltcorn/types/common_types";
 import { runWithTenant } from "@saltcorn/db-common/multi-tenant";
 
@@ -19,6 +26,7 @@ import * as mocks from "./mocks.js";
 import User from "../models/user.js";
 import Table from "../models/table.js";
 import WorkflowTrace from "../models/workflow_trace.js";
+import { sleep } from "../utils.js";
 const { mockReqRes } = mocks;
 
 afterAll(db.close);
@@ -107,7 +115,9 @@ describe("Workflow run steps", () => {
     const trigger0 = Trigger.findOne({ name: "mywf" });
 
     assertIsSet(trigger0);
-    await Trigger.update(trigger0.id!, { configuration: { save_traces: true } });
+    await Trigger.update(trigger0.id!, {
+      configuration: { save_traces: true },
+    });
     const trigger = Trigger.findOne({ name: "mywf" });
     assertIsSet(trigger);
 
@@ -962,5 +972,192 @@ describe("Workflow step operations", () => {
     );
     expect(diagram).toContain("_Start--");
     expect(diagram).toContain("--> _End__subgraph_");
+  });
+});
+
+describe("Workflow mutex", () => {
+  let logTable: Table;
+
+  beforeAll(async () => {
+    logTable = await Table.create("wf_mutex_log");
+    await Field.create({
+      table: logTable,
+      name: "case",
+      label: "case",
+      type: "String",
+    });
+    await Field.create({
+      table: logTable,
+      name: "phase",
+      label: "phase",
+      type: "String",
+    });
+  });
+
+  const markers = async (caseName: string): Promise<string[]> => {
+    const rows = await logTable.getRows({ case: caseName }, { orderBy: "id" });
+    return rows.map((r: any) => r.phase);
+  };
+
+  const logStepCode = (caseName: string, sleepMs: number) => `
+    const table = Table.findOne({name: "wf_mutex_log"});
+    await table.insertRow({case: "${caseName}", phase: "start"});
+    await sleep(${sleepMs});
+    await table.insertRow({case: "${caseName}", phase: "end"});
+    return {};
+  `;
+
+  it("step-scoped lock keeps concurrent runs from overlapping", async () => {
+    const user = await User.findOne({ id: 1 });
+    assertIsSet(user);
+    const trigger = await Trigger.create({
+      action: "Workflow",
+      when_trigger: "Never",
+      name: "mutex_steplock_wf",
+    });
+    await WorkflowStep.create({
+      trigger_id: trigger.id!,
+      name: "locked_step",
+      action_name: "run_js_code",
+      initial_step: true,
+      configuration: {
+        mutex_enabled: true,
+        mutex_lock_name: `"ts-steplock"`,
+        code: logStepCode("steplock", 300),
+        run_where: "Server",
+      },
+    });
+
+    const run1 = await WorkflowRun.create({ trigger_id: trigger.id! });
+    const run2 = await WorkflowRun.create({ trigger_id: trigger.id! });
+    await Promise.all([run1.run({ user }), run2.run({ user })]);
+
+    expect(await markers("steplock")).toStrictEqual([
+      "start",
+      "end",
+      "start",
+      "end",
+    ]);
+  });
+
+  // Without the lock, the same setup should overlap instead - proving
+  // this test can actually tell locked from unlocked.
+  it("without the lock, concurrent runs interleave", async () => {
+    const user = await User.findOne({ id: 1 });
+    assertIsSet(user);
+    const trigger = await Trigger.create({
+      action: "Workflow",
+      when_trigger: "Never",
+      name: "mutex_nolock_wf",
+    });
+    await WorkflowStep.create({
+      trigger_id: trigger.id!,
+      name: "unlocked_step",
+      action_name: "run_js_code",
+      initial_step: true,
+      configuration: {
+        code: logStepCode("nolock", 300),
+        run_where: "Server",
+      },
+    });
+
+    const run1 = await WorkflowRun.create({ trigger_id: trigger.id! });
+    const run2 = await WorkflowRun.create({ trigger_id: trigger.id! });
+    await Promise.all([run1.run({ user }), run2.run({ user })]);
+
+    expect(await markers("nolock")).toStrictEqual([
+      "start",
+      "start",
+      "end",
+      "end",
+    ]);
+  });
+
+  it("run-scoped AcquireLock/ReleaseLock keeps concurrent runs from overlapping across steps", async () => {
+    const user = await User.findOne({ id: 1 });
+    assertIsSet(user);
+    const trigger = await Trigger.create({
+      action: "Workflow",
+      when_trigger: "Never",
+      name: "mutex_runlock_wf",
+    });
+    await WorkflowStep.create({
+      trigger_id: trigger.id!,
+      name: "acquire",
+      action_name: "AcquireLock",
+      next_step: "log",
+      initial_step: true,
+      configuration: { lock_name: `"ts-runlock"` },
+    });
+    await WorkflowStep.create({
+      trigger_id: trigger.id!,
+      name: "log",
+      action_name: "run_js_code",
+      next_step: "release",
+      initial_step: false,
+      configuration: {
+        code: logStepCode("runlock", 300),
+        run_where: "Server",
+      },
+    });
+    await WorkflowStep.create({
+      trigger_id: trigger.id!,
+      name: "release",
+      action_name: "ReleaseLock",
+      initial_step: false,
+      configuration: { lock_name: `"ts-runlock"` },
+    });
+
+    const run1 = await WorkflowRun.create({ trigger_id: trigger.id! });
+    const run2 = await WorkflowRun.create({ trigger_id: trigger.id! });
+    await Promise.all([run1.run({ user }), run2.run({ user })]);
+
+    expect(await markers("runlock")).toStrictEqual([
+      "start",
+      "end",
+      "start",
+      "end",
+    ]);
+  });
+
+  // First run holds the lock for 1s; the second, started 200ms later with
+  // a 300ms timeout, should fail while the first is still holding it.
+  it("lock timeout fails a run that can't acquire in time", async () => {
+    const user = await User.findOne({ id: 1 });
+    assertIsSet(user);
+    const trigger = await Trigger.create({
+      action: "Workflow",
+      when_trigger: "Never",
+      name: "mutex_timeout_wf",
+    });
+    await WorkflowStep.create({
+      trigger_id: trigger.id!,
+      name: "locked_step",
+      action_name: "run_js_code",
+      initial_step: true,
+      configuration: {
+        mutex_enabled: true,
+        mutex_lock_name: `"ts-timeoutlock"`,
+        mutex_lock_timeout: 0.3,
+        code: logStepCode("timeoutlock", 1000),
+        run_where: "Server",
+      },
+    });
+
+    const run1 = await WorkflowRun.create({ trigger_id: trigger.id! });
+    const run2 = await WorkflowRun.create({ trigger_id: trigger.id! });
+
+    const firstPromise = run1.run({ user });
+    await sleep(200); // let run1 acquire the lock and start its 1s sleep
+    // markAsError logs the (here, expected) failure to console.error -
+    // silence it for just this call so the test output stays clean
+    const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    await run2.run({ user });
+    errSpy.mockRestore();
+    await firstPromise;
+
+    expect(run2.status).toBe("Error");
+    expect(String(run2.error)).toMatch(/lock timeout/i);
+    expect(await markers("timeoutlock")).toStrictEqual(["start", "end"]);
   });
 });

--- a/packages/saltcorn-data/utils.ts
+++ b/packages/saltcorn-data/utils.ts
@@ -214,6 +214,19 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Runs fn() while holding a cross-node exclusive lock named `name`,
+ * released as soon as fn() finishes or throws.
+ */
+async function withLock<T>(
+  name: string,
+  fn: () => Promise<T>,
+  opts: { timeoutMs?: number } = {}
+): Promise<T> {
+  const { MultiNodeMutex } = await import("./models/multi_node_mutex.js");
+  return await new MultiNodeMutex().withLock(name, fn, opts);
+}
+
 const mergeIntoWhere = (where: Where, newWhere: GenObj) => {
   Object.entries(newWhere).forEach(([k, v]) => {
     if (k == "or") {
@@ -942,6 +955,7 @@ export {
   getLines,
   removeAllWhiteSpace,
   sleep,
+  withLock,
   mergeIntoWhere,
   isStale,
   isNode,

--- a/packages/server/help/JavaScript action code.tmd
+++ b/packages/server/help/JavaScript action code.tmd
@@ -68,6 +68,18 @@ which is the same as
 const data = await fetchJSON('https://api.github.com/users/github');
 ```
 
+#### `withLock`
+
+Run code while holding a named lock, so that no other run holding the same lock name (even on a different server node) can proceed until it finishes.
+
+Example:
+
+```
+await withLock("invoice-" + customer_id, async () => {
+  await table.insertRow({customer_id, total: 42})
+})
+```
+
 ## Return directives
 
 Your code can with its return value give directives to the current page. 

--- a/packages/server/routes/actions.ts
+++ b/packages/server/routes/actions.ts
@@ -1032,10 +1032,6 @@ const getWorkflowStepForm = async (
     builtIns: Object.keys(builtInActionExplainers),
     forWorkflow: true,
   });
-  // AcquireLock/ReleaseLock steps don't need the lock option below.
-  const actionsAllowingMutex = actionsNotRequiringRow
-    .flatMap((g: any) => g.options || [])
-    .filter((name: string) => name !== "AcquireLock" && name !== "ReleaseLock");
   const triggers = Trigger.find({
     when_trigger: { or: ["API call", "Never"] },
   })!;
@@ -1087,33 +1083,6 @@ const getWorkflowStepForm = async (
           "Name of next step. Can be a JavaScript expression based on the run context. Blank if final step",
       },
       {
-        name: "mutex_enabled",
-        label: req.__("Protect with lock"),
-        sublabel: "Run this step only while holding a named lock.",
-        type: "Bool",
-        showIf: { wf_action_name: actionsAllowingMutex },
-      },
-      {
-        name: "mutex_lock_name",
-        label: req.__("Lock name"),
-        class: "validate-expression",
-        sublabel:
-          "JavaScript expression, e.g. " +
-          "<code>&quot;mylock&quot;</code> for a fixed name, or " +
-          "<code>&quot;invoice-&quot;+customer_id</code> using a variable. Released " +
-          "when the step finishes.",
-        type: "String",
-        showIf: { mutex_enabled: true, wf_action_name: actionsAllowingMutex },
-      },
-      {
-        name: "mutex_lock_timeout",
-        label: req.__("Lock timeout (s)"),
-        sublabel:
-          "Optional. If the lock is not acquired within this many seconds, the step fails instead of waiting. Leave blank for a default 30s wait, or set to 0 to wait forever.",
-        type: "Float",
-        showIf: { mutex_enabled: true, wf_action_name: actionsAllowingMutex },
-      },
-      {
         input_type: "section_header",
         label: req.__("Action"),
       },
@@ -1133,12 +1102,6 @@ const getWorkflowStepForm = async (
       },
       ...actionConfigFields,
     ],
-    validator: (vs: any) => {
-      if (vs.mutex_enabled && !vs.mutex_lock_name)
-        return req.__(
-          'Lock name is required when "Protect with lock" is enabled'
-        );
-    },
   });
   form.hidden("wf_step_id");
   form.hidden("_after_step");

--- a/packages/server/routes/actions.ts
+++ b/packages/server/routes/actions.ts
@@ -1032,6 +1032,10 @@ const getWorkflowStepForm = async (
     builtIns: Object.keys(builtInActionExplainers),
     forWorkflow: true,
   });
+  // AcquireLock/ReleaseLock steps don't need the lock option below.
+  const actionsAllowingMutex = actionsNotRequiringRow
+    .flatMap((g: any) => g.options || [])
+    .filter((name: string) => name !== "AcquireLock" && name !== "ReleaseLock");
   const triggers = Trigger.find({
     when_trigger: { or: ["API call", "Never"] },
   })!;
@@ -1085,8 +1089,9 @@ const getWorkflowStepForm = async (
       {
         name: "mutex_enabled",
         label: req.__("Protect with lock"),
-        sublabel: "Serialize this step using a cross-node lock.",
+        sublabel: "Run this step only while holding a named lock.",
         type: "Bool",
+        showIf: { wf_action_name: actionsAllowingMutex },
       },
       {
         name: "mutex_lock_name",
@@ -1095,7 +1100,7 @@ const getWorkflowStepForm = async (
         sublabel:
           "Can be an expression, e.g. <code>&quot;invoice-&quot;+customer_id</code>. Released when the step finishes.",
         type: "String",
-        showIf: { mutex_enabled: true },
+        showIf: { mutex_enabled: true, wf_action_name: actionsAllowingMutex },
       },
       {
         name: "mutex_lock_timeout",
@@ -1103,7 +1108,7 @@ const getWorkflowStepForm = async (
         sublabel:
           "Optional. If the lock is not acquired within this many seconds, the step fails instead of waiting indefinitely.",
         type: "Float",
-        showIf: { mutex_enabled: true },
+        showIf: { mutex_enabled: true, wf_action_name: actionsAllowingMutex },
       },
       {
         input_type: "section_header",

--- a/packages/server/routes/actions.ts
+++ b/packages/server/routes/actions.ts
@@ -1106,7 +1106,7 @@ const getWorkflowStepForm = async (
         name: "mutex_lock_timeout",
         label: req.__("Lock timeout (s)"),
         sublabel:
-          "Optional. If the lock is not acquired within this many seconds, the step fails instead of waiting indefinitely.",
+          "Optional. If the lock is not acquired within this many seconds, the step fails instead of waiting. Leave blank for a default 30s wait, or set to 0 to wait forever.",
         type: "Float",
         showIf: { mutex_enabled: true, wf_action_name: actionsAllowingMutex },
       },
@@ -1130,6 +1130,12 @@ const getWorkflowStepForm = async (
       },
       ...actionConfigFields,
     ],
+    validator: (vs: any) => {
+      if (vs.mutex_enabled && !vs.mutex_lock_name)
+        return req.__(
+          'Lock name is required when "Protect with lock" is enabled'
+        );
+    },
   });
   form.hidden("wf_step_id");
   form.hidden("_after_step");

--- a/packages/server/routes/actions.ts
+++ b/packages/server/routes/actions.ts
@@ -1083,6 +1083,29 @@ const getWorkflowStepForm = async (
           "Name of next step. Can be a JavaScript expression based on the run context. Blank if final step",
       },
       {
+        name: "mutex_enabled",
+        label: req.__("Protect with lock"),
+        sublabel: "Serialize this step using a cross-node lock.",
+        type: "Bool",
+      },
+      {
+        name: "mutex_lock_name",
+        label: req.__("Lock name"),
+        class: "validate-expression",
+        sublabel:
+          "Can be an expression, e.g. <code>&quot;invoice-&quot;+customer_id</code>. Released when the step finishes.",
+        type: "String",
+        showIf: { mutex_enabled: true },
+      },
+      {
+        name: "mutex_lock_timeout",
+        label: req.__("Lock timeout (s)"),
+        sublabel:
+          "Optional. If the lock is not acquired within this many seconds, the step fails instead of waiting indefinitely.",
+        type: "Float",
+        showIf: { mutex_enabled: true },
+      },
+      {
         input_type: "section_header",
         label: req.__("Action"),
       },

--- a/packages/server/routes/actions.ts
+++ b/packages/server/routes/actions.ts
@@ -1098,7 +1098,10 @@ const getWorkflowStepForm = async (
         label: req.__("Lock name"),
         class: "validate-expression",
         sublabel:
-          "Can be an expression, e.g. <code>&quot;invoice-&quot;+customer_id</code>. Released when the step finishes.",
+          "JavaScript expression, e.g. " +
+          "<code>&quot;mylock&quot;</code> for a fixed name, or " +
+          "<code>&quot;invoice-&quot;+customer_id</code> using a variable. Released " +
+          "when the step finishes.",
         type: "String",
         showIf: { mutex_enabled: true, wf_action_name: actionsAllowingMutex },
       },


### PR DESCRIPTION
Postgres based mutex locks that works in a multinode setup
- workflow mutex
  - insert Aquire/Release steps to keep a lock for one or multiple steps
- run_js_code mutex
  - the sandbox has a withLock function with a callback for the code that should be protected

#4231 