### PR TITLE
Show images from subfolders in builders

### DIFF
--- a/packages/saltcorn-data/base-plugin/viewtemplates/edit.ts
+++ b/packages/saltcorn-data/base-plugin/viewtemplates/edit.ts
@@ -119,7 +119,7 @@ const configuration_workflow = (req: Req) =>
             calcfldViewOptions(fields, "edit");
 
           const roles = await User.get_roles();
-          const images = await File.find({ mime_super: "image" });
+          const images = await File.findImagesForBuilder();
           const stateActions = (
             Object.entries(getState()!.actions) as [string, GenObj][]
           ).filter(([k, v]) => !v.disableInBuilder && !v.disableIf?.());

--- a/packages/saltcorn-data/base-plugin/viewtemplates/list.ts
+++ b/packages/saltcorn-data/base-plugin/viewtemplates/list.ts
@@ -266,7 +266,7 @@ const configuration_workflow = (req: Req) =>
               name: g.name,
             })
           );
-          const images = await File.find({ mime_super: "image" });
+          const images = await File.findImagesForBuilder();
           const library = (await Library.find({})).filter((l: GenObj) =>
             l.suitableFor("list")
           );

--- a/packages/saltcorn-data/base-plugin/viewtemplates/show.ts
+++ b/packages/saltcorn-data/base-plugin/viewtemplates/show.ts
@@ -239,7 +239,7 @@ const configuration_workflow = (req: Req) =>
               name: g.name,
             })
           );
-          const images = await File.find({ mime_super: "image" });
+          const images = await File.findImagesForBuilder();
           const library = (await Library.find({})).filter((l: GenObj) =>
             l.suitableFor("show")
           );

--- a/packages/saltcorn-data/models/file.ts
+++ b/packages/saltcorn-data/models/file.ts
@@ -206,17 +206,20 @@ class File {
   }
 
   static async findImagesForBuilder(): Promise<
-    Array<{ id: number | string; filename: string; location: string }>
+    Array<{ id: string; filename: string; location: string }>
   > {
     const images = await this.find(
       { mime_super: "image" },
       { recursive: true }
     );
-    return images.map((image) => ({
-      id: image.id ?? image.field_value,
-      filename: image.path_to_serve,
-      location: image.field_value,
-    }));
+
+    return images
+      .filter((image) => !image.isDirectory)
+      .map((image) => ({
+        id: image.field_value,
+        filename: image.path_to_serve,
+        location: image.field_value,
+      }));
   }
 
   static normalise(fpath: string): string {

--- a/packages/saltcorn-data/models/file.ts
+++ b/packages/saltcorn-data/models/file.ts
@@ -204,6 +204,21 @@ class File {
       return files.filter(pred);
     }
   }
+
+  static async findImagesForBuilder(): Promise<
+    Array<{ id: number | string; filename: string; location: string }>
+  > {
+    const images = await this.find(
+      { mime_super: "image" },
+      { recursive: true }
+    );
+    return images.map((image) => ({
+      id: image.id ?? image.field_value,
+      filename: image.path_to_serve,
+      location: image.field_value,
+    }));
+  }
+
   static normalise(fpath: string): string {
     return path.normalize(fpath).replace(/^(\.\.(\/|\\|$))+/, "");
   }

--- a/packages/saltcorn-data/tests/file.test.ts
+++ b/packages/saltcorn-data/tests/file.test.ts
@@ -127,12 +127,12 @@ describe("File class", () => {
       const images = await File.findImagesForBuilder();
 
       expect(images).toContainEqual({
-        id: rootImage.id,
+        id: rootImage.field_value,
         filename: "builder-selector.png",
         location: "builder-selector.png",
       });
       expect(images).toContainEqual({
-        id: nestedImage.id,
+        id: nestedImage.field_value,
         filename: `${subfolder}/builder-selector.png`,
         location: `${subfolder}/builder-selector.png`,
       });

--- a/packages/saltcorn-data/tests/file.test.ts
+++ b/packages/saltcorn-data/tests/file.test.ts
@@ -99,6 +99,49 @@ describe("File class", () => {
     expect(labels).toContain(`${subfolder}/nested.txt`);
   });
 
+  it("findImagesForBuilder includes image paths from subfolders", async () => {
+    const subfolder = "builder_image_options";
+    if (
+      !existsSync(
+        join(db.connectObj.file_store, db.getTenantSchema(), subfolder)
+      )
+    )
+      await File.new_folder(subfolder);
+    const rootImage = await File.from_contents(
+      "builder-selector.png",
+      "image/png",
+      "root image",
+      1,
+      100
+    );
+    const nestedImage = await File.from_contents(
+      "builder-selector.png",
+      "image/png",
+      "nested image",
+      1,
+      100,
+      subfolder
+    );
+
+    try {
+      const images = await File.findImagesForBuilder();
+
+      expect(images).toContainEqual({
+        id: rootImage.id,
+        filename: "builder-selector.png",
+        location: "builder-selector.png",
+      });
+      expect(images).toContainEqual({
+        id: nestedImage.id,
+        filename: `${subfolder}/builder-selector.png`,
+        location: `${subfolder}/builder-selector.png`,
+      });
+    } finally {
+      await rootImage.delete();
+      await nestedImage.delete();
+    }
+  });
+
   it("should find in subfolders", async () => {
     const subfolder = "subfolder";
     const fileName = "fileName2.html";

--- a/packages/server/routes/pageedit.ts
+++ b/packages/server/routes/pageedit.ts
@@ -176,8 +176,7 @@ const pageBuilderData = async (req: Req, context: any) => {
   const views = (await View.find())!;
   const pages = (await Page.find())!;
   const page_groups = (await PageGroup.find()).map((g: any) => ({ name: g.name }));
-  const images = (await File.find({ mime_super: "image" }))!;
-  images.forEach((im: any) => (im.location = im.field_value));
+  const images = await File.findImagesForBuilder();
   const roles = await User.get_roles();
   const stateActions = getState()!.actions;
   const actions = [


### PR DESCRIPTION
Fixes #4329

- Load images recursively for page and view builders
- Show relative paths so files with the same name remain distinguishable
- Keep path-based storage entries selectable when no numeric id is available

Tests:
- `tsc --build packages/server/tsconfig.ref.json`
- Added regression coverage for root and nested images with the same filename