### PR TITLE
Fix getRows ownership checks for joined fields

### DIFF
--- a/packages/saltcorn-data/models/table.ts
+++ b/packages/saltcorn-data/models/table.ts
@@ -1629,6 +1629,24 @@ class Table implements AbstractTable {
     const use_forUser =
       (this.constructor as typeof Table).fixed_user || forUser;
     const role = use_forUser ? use_forUser.role_id : forPublic ? 100 : null;
+    const ownershipJoinFields: JoinFields = {};
+    if (
+      !this.canEnforceRls() &&
+      role &&
+      role > this.min_role_read &&
+      this.ownership_formula &&
+      !selopts.disable_ownership_postqfilter
+    )
+      add_free_variables_to_joinfields(
+        freeVariables(this.ownership_formula),
+        ownershipJoinFields,
+        fields
+      );
+    const includePrimaryKeyForOwnership =
+      !db.isSQLite &&
+      Object.keys(ownershipJoinFields).length > 0 &&
+      !!selopts1.fields &&
+      !selopts1.fields.includes(this.pk_name);
     return this.withRlsUser(use_forUser, async () => {
       if (
         !this.canEnforceRls() &&
@@ -1645,7 +1663,12 @@ class Table implements AbstractTable {
       let rows = await db.select(
         this.name,
         where,
-        this.processSelectOptions(selopts1)
+        this.processSelectOptions({
+          ...selopts1,
+          fields: includePrimaryKeyForOwnership
+            ? [...(selopts1.fields || []), this.pk_name]
+            : selopts1.fields,
+        })
       );
       if (!this.canEnforceRls() && role && role > this.min_role_read) {
         //check ownership
@@ -1653,15 +1676,42 @@ class Table implements AbstractTable {
         else if (this.ownership_field_id) {
           //already dealt with by changing where
         } else if (this.ownership_formula || this.name === "users") {
-          if (!selopts?.disable_ownership_postqfilter)
-            rows = rows.filter((row: Row) => this.is_owner(use_forUser, row));
+          if (!selopts?.disable_ownership_postqfilter) {
+            if (Object.keys(ownershipJoinFields).length && rows.length) {
+              const ownedPrimaryKeys = new Set<Value>();
+              const primaryKey = this.pk_name;
+              for (let offset = 0; offset < rows.length; offset += 500) {
+                const batch = rows.slice(offset, offset + 500);
+                const joinedRows = await this.getJoinedRows({
+                  where: {
+                    [primaryKey]: {
+                      in: batch.map((row: Row) => row[primaryKey]),
+                    },
+                  },
+                  forUser: use_forUser,
+                  ignore_errors: selopts.ignore_errors,
+                });
+                joinedRows.forEach((row: Row) =>
+                  ownedPrimaryKeys.add(row[primaryKey])
+                );
+              }
+              rows = rows.filter((row: Row) =>
+                ownedPrimaryKeys.has(row[primaryKey])
+              );
+            } else {
+              rows = rows.filter((row: Row) => this.is_owner(use_forUser, row));
+            }
+          }
         } else return []; //no ownership
       }
-      return apply_calculated_fields(
+      const result = apply_calculated_fields(
         rows.map((r: Row) => this.readFromDB(this.parse_json_fields(r))),
         this.fields,
         !!selopts.ignore_errors
       );
+      if (includePrimaryKeyForOwnership)
+        result.forEach((row: Row) => delete row[this.pk_name]);
+      return result;
     });
   }
 

--- a/packages/saltcorn-data/models/table.ts
+++ b/packages/saltcorn-data/models/table.ts
@@ -1564,12 +1564,34 @@ class Table implements AbstractTable {
       (this.constructor as typeof Table).fixed_user || forUser;
 
     const role = use_forUser ? use_forUser.role_id : forPublic ? 100 : null;
+    const ownershipJoinFields: JoinFields = {};
+    if (
+      !this.canEnforceRls() &&
+      role &&
+      role > this.min_role_read &&
+      this.ownership_formula
+    )
+      add_free_variables_to_joinfields(
+        freeVariables(this.ownership_formula),
+        ownershipJoinFields,
+        fields
+      );
+    const includePrimaryKeyForOwnership =
+      !db.isSQLite &&
+      Object.keys(ownershipJoinFields).length > 0 &&
+      !!selopts1.fields &&
+      !selopts1.fields.includes(this.pk_name);
     return this.withRlsUser(use_forUser, async () => {
       this.normalise_fkey_values(where);
       const row = await db.selectMaybeOne(
         this.name,
         where,
-        this.processSelectOptions(selopts1)
+        this.processSelectOptions({
+          ...selopts1,
+          fields: includePrimaryKeyForOwnership
+            ? [...(selopts1.fields || []), this.pk_name]
+            : selopts1.fields,
+        })
       );
       if (!row || !this.fields) return null;
       if (!this.canEnforceRls() && role && role > this.min_role_read) {
@@ -1584,13 +1606,22 @@ class Table implements AbstractTable {
           if (row[owner_field.name] !== (use_forUser as AbstractUser).id)
             return null;
         } else if (this.ownership_formula || this.name === "users") {
-          if (!this.is_owner(use_forUser, row)) return null;
+          if (Object.keys(ownershipJoinFields).length) {
+            const joinedRow = await this.getJoinedRow({
+              where: { [this.pk_name]: row[this.pk_name] },
+              forUser: use_forUser,
+              ignore_errors: selopts.ignore_errors,
+            });
+            if (!joinedRow) return null;
+          } else if (!this.is_owner(use_forUser, row)) return null;
         } else return null; //no ownership
       }
-      return apply_calculated_fields(
+      const result = apply_calculated_fields(
         [this.readFromDB(this.parse_json_fields(row))],
         this.fields
       )[0];
+      if (includePrimaryKeyForOwnership) delete result[this.pk_name];
+      return result;
     });
   }
 

--- a/packages/saltcorn-data/tests/auth.test.ts
+++ b/packages/saltcorn-data/tests/auth.test.ts
@@ -675,6 +675,21 @@ describe("Table with row ownership joined formula nocalc", () => {
     expect(selected_owned_rows[0].lastname).toBe("Sam");
     if (!db.isSQLite)
       expect(selected_owned_rows).toStrictEqual([{ lastname: "Sam" }]);
+    const owned_row_get = await persons.getRow(
+      { lastname: "Sam" },
+      { forUser: owner_user }
+    );
+    expect(owned_row_get?.lastname).toBe("Sam");
+    expect(
+      await persons.getRow({ lastname: "Joe" }, { forUser: owner_user })
+    ).toBe(null);
+    const selected_owned_row = await persons.getRow(
+      { lastname: "Sam" },
+      { forUser: owner_user, fields: ["lastname"] }
+    );
+    expect(selected_owned_row?.lastname).toBe("Sam");
+    if (!db.isSQLite)
+      expect(selected_owned_row).toStrictEqual({ lastname: "Sam" });
     await test_person_table(persons);
     //insert
     await persons.insertRow(

--- a/packages/saltcorn-data/tests/auth.test.ts
+++ b/packages/saltcorn-data/tests/auth.test.ts
@@ -663,6 +663,18 @@ describe("Table with row ownership joined formula nocalc", () => {
 
     await persons.insertRow({ lastname: "Joe", age: 12, department: 2 });
     await persons.insertRow({ lastname: "Sam", age: 13, department: 1 });
+    const owned_rows = await persons.getRows({}, { forUser: owner_user });
+    expect(owned_rows.length).toBe(1);
+    expect(owned_rows[0].lastname).toBe("Sam");
+    expect(owned_rows[0].department).toBe(1);
+    const selected_owned_rows = await persons.getRows(
+      {},
+      { forUser: owner_user, fields: ["lastname"] }
+    );
+    expect(selected_owned_rows.length).toBe(1);
+    expect(selected_owned_rows[0].lastname).toBe("Sam");
+    if (!db.isSQLite)
+      expect(selected_owned_rows).toStrictEqual([{ lastname: "Sam" }]);
     await test_person_table(persons);
     //insert
     await persons.insertRow(


### PR DESCRIPTION
## Summary

- evaluate ownership formulas that reference joined fields against joined rows
- keep the original `getRows` result shape and ordering while filtering by authorized primary keys
- batch authorization lookups and cover projected-field behavior with a regression test

Fixes #3954

## Testing

- `npm run tsc`
- `node --require ../setup-test-schema.cjs --test --test-concurrency=1 --test-force-exit tests/auth.test.js` (30 tests)
- `node --require ../setup-test-schema.cjs --test --test-concurrency=1 --test-force-exit tests/table.test.js`