### PR TITLE
feat: add built-in Send SMS action

### DIFF
--- a/packages/saltcorn-data/base-plugin/actions.ts
+++ b/packages/saltcorn-data/base-plugin/actions.ts
@@ -12,6 +12,7 @@ import {
   getFileAggregations,
   mjml2html,
 } from "../models/email.js";
+import { sendSMS } from "../models/sms.js";
 import {
   get_async_expression_function,
   recalculate_for_stored,
@@ -1302,6 +1303,251 @@ export default {
         }
         if (disable_notify) return;
         else return { notify: `E-mail sent to ${to_addr}` };
+      } catch (e) {
+        if (confirm_field) {
+          const confirm_fld = table.getField(confirm_field);
+          if (
+            confirm_fld &&
+            (typeof confirm_fld.type === "string"
+              ? confirm_fld.type === "Bool"
+              : confirm_fld.type?.name === "Bool")
+          )
+            await table.updateRow(
+              { [confirm_field]: false },
+              row[table.pk_name]
+            );
+          throw e;
+        }
+      }
+    },
+    namespace: "Communication",
+  },
+
+  /**
+   * @namespace
+   * @category saltcorn-data
+   * @subcategory actions
+   */
+  send_sms: {
+    /**
+     * @param {object} opts
+     * @param {object} opts.table
+     * @returns {Promise<object[]>}
+     */
+    description: "Send an SMS text message",
+    configFields: async ({
+      table,
+      mode,
+    }: {
+      table?: Table;
+      mode?: string;
+    }) => {
+      if (mode === "workflow") {
+        return [
+          {
+            name: "to_phone",
+            label: "To",
+            sublabel:
+              "Phone number(s) in E.164 format (for instance, +15551234567), comma separated, <code>{{ }}</code> interpolations usable",
+            type: "String",
+            required: true,
+          },
+          {
+            name: "body",
+            label: "Message",
+            type: "String",
+            fieldview: "textarea",
+            required: true,
+          },
+          {
+            name: "confirm_field",
+            label: "Send confirmation variable",
+            type: "String",
+            sublabel:
+              "Bool variable set in context indicate successful sending of SMS message",
+          },
+        ];
+      }
+      if (!table) return [];
+      const fields = table.getFields();
+      const field_opts = fields
+        .filter((f) => f.type_name === "String")
+        .map((f) => f.name);
+      const confirm_field_opts = fields
+        .filter((f) => f.type_name === "Bool" || f.type_name === "Date")
+        .map((f) => f.name);
+      return [
+        {
+          name: "to_phone",
+          label: "Recipient phone number",
+          sublabel:
+            "Select the source of the phone number to send the SMS to",
+          input_type: "select",
+          required: true,
+          options: ["Fixed", "Field"],
+        },
+        {
+          name: "to_phone_field",
+          label: "Field with phone number",
+          sublabel:
+            "String field holding a phone number in E.164 format (for instance, +15551234567)",
+          input_type: "select",
+          options: field_opts,
+          showIf: { to_phone: "Field" },
+        },
+        {
+          name: "to_phone_fixed",
+          label: "Fixed number",
+          sublabel:
+            "Phone number(s) in E.164 format, comma separated, <code>{{ }}</code> interpolations usable",
+          type: "String",
+          showIf: { to_phone: "Fixed" },
+        },
+        {
+          name: "body",
+          label: "Message",
+          sublabel: "Text of the SMS message, <code>{{ }}</code> interpolations usable",
+          type: "String",
+          fieldview: "textarea",
+          required: true,
+        },
+        {
+          name: "only_if",
+          label: "Only if",
+          sublabel:
+            "Only send SMS if this formula evaluates to true. Leave blank to always send",
+          type: "String",
+        },
+        { name: "disable_notify", label: "Disable notification", type: "Bool" },
+        {
+          name: "confirm_field",
+          label: "Send confirmation field",
+          type: "String",
+          sublabel:
+            "Bool or Date field to indicate successful sending of SMS message",
+          attributes: {
+            options: confirm_field_opts,
+          },
+        },
+      ];
+    },
+    requireRow: true,
+    /**
+     * @param {object} opts
+     * @param {object} opts.row
+     * @param {object} opts.table
+     * @param {object} opts.configuration
+     * @param {object} opts.user
+     * @returns {Promise<object>}
+     */
+    run: async ({
+      row,
+      table,
+      configuration: {
+        to_phone,
+        to_phone_field,
+        to_phone_fixed,
+        body,
+        only_if,
+        disable_notify,
+        confirm_field,
+      },
+      user,
+      mode,
+    }: {
+      row: Row;
+      table: Table;
+      configuration: {
+        to_phone: string;
+        to_phone_field?: string;
+        to_phone_fixed?: string;
+        body?: string;
+        only_if?: string;
+        disable_notify?: boolean;
+        confirm_field?: string;
+      };
+      user: User;
+      mode: string;
+    }) => {
+      if (mode === "workflow") {
+        const to_addr = interpolate(to_phone, row, user, "send_sms to number");
+        const the_body = interpolate(body, row, user, "send_sms body");
+        try {
+          await sendSMS(to_addr, the_body!);
+          if (confirm_field) return { [confirm_field]: true };
+          return;
+        } catch (e: any) {
+          if (confirm_field) return { [confirm_field]: false };
+          throw e;
+        }
+      }
+      let to_addr;
+      let useRow: Row | null = row;
+      const fvs = [
+        ...freeVariablesInInterpolation(to_phone_fixed),
+        ...freeVariablesInInterpolation(body),
+        ...freeVariables(only_if),
+      ];
+      if (fvs.length > 0) {
+        const joinFields = {};
+        const fields = table.getFields();
+        add_free_variables_to_joinfields(new Set(fvs), joinFields, fields);
+        useRow = await table.getJoinedRow({
+          where: { [table.pk_name]: row[table.pk_name] },
+          joinFields,
+          forUser: user,
+        });
+      }
+
+      if (only_if) {
+        const bres = eval_expression(
+          only_if,
+          useRow,
+          user,
+          "send_sms only if formula"
+        );
+        if (!bres) return;
+      }
+      switch (to_phone) {
+        case "Fixed":
+          to_addr = interpolate(
+            to_phone_fixed,
+            useRow,
+            user,
+            "send_sms to number"
+          );
+          break;
+        case "Field":
+          to_addr = row[to_phone_field as string];
+          break;
+      }
+      if (!to_addr) {
+        getState()!.log(
+          2,
+          `send_sms action: Not sending as phone number ${to_phone} is missing`
+        );
+        return;
+      }
+      const the_body = interpolate(body, useRow, user, "send_sms body");
+      getState()!.log(3, `Sending SMS to ${to_addr}`);
+      try {
+        const sendres = await sendSMS(to_addr, the_body!);
+        getState()!.log(5, `send_sms result: ${JSON.stringify(sendres)}`);
+        if (confirm_field) {
+          const confirm_fld = table.getField(confirm_field);
+          if (confirm_fld && confirm_fld.type_name === "Date")
+            await table.updateRow(
+              { [confirm_field]: new Date() },
+              row[table.pk_name]
+            );
+          else if (confirm_fld && confirm_fld.type_name === "Bool")
+            await table.updateRow(
+              { [confirm_field]: true },
+              row[table.pk_name]
+            );
+        }
+        if (disable_notify) return;
+        else return { notify: `SMS sent to ${to_addr}` };
       } catch (e) {
         if (confirm_field) {
           const confirm_fld = table.getField(confirm_field);

--- a/packages/saltcorn-data/cjs/models/sms.cjs
+++ b/packages/saltcorn-data/cjs/models/sms.cjs
@@ -1,0 +1,18 @@
+// CommonJS interop shim — AUTO-GENERATED, DO NOT EDIT.
+// See gen-cjs-shims.cjs.
+"use strict";
+const m = require("../../dist/models/sms.js");
+const e = m && m.__esModule && "default" in m ? m.default : m;
+module.exports = e;
+if (e !== m && e && (typeof e === "object" || typeof e === "function")) {
+  for (const k in m) {
+    if (k === "default" || k === "__esModule" || k in e) continue;
+    try {
+      Object.defineProperty(e, k, {
+        get: () => m[k],
+        enumerable: true,
+        configurable: true,
+      });
+    } catch {}
+  }
+}

--- a/packages/saltcorn-data/models/config.ts
+++ b/packages/saltcorn-data/models/config.ts
@@ -625,6 +625,46 @@ const configTypes: ConfigTypes = {
     excludeFromMobile: true,
     ephemeral: true,
   },
+  sms_provider: {
+    type: "String",
+    label: "SMS provider",
+    default: "Twilio",
+    blurb: "The service used to send SMS text messages from the 'Send SMS' action.",
+    input_type: "select",
+    options: ["Twilio", "Generic webhook"],
+    excludeFromMobile: true,
+  },
+  twilio_account_sid: {
+    type: "String",
+    label: "Twilio Account SID",
+    default: "",
+    blurb: "Found on your Twilio Console dashboard.",
+    excludeFromMobile: true,
+  },
+  twilio_auth_token: {
+    type: "String",
+    label: "Twilio Auth token",
+    default: "",
+    input_type: "password",
+    blurb: "Found on your Twilio Console dashboard.",
+    excludeFromMobile: true,
+  },
+  twilio_from_number: {
+    type: "String",
+    label: "Twilio From number",
+    default: "",
+    blurb:
+      "The Twilio phone number messages are sent from, in E.164 format (for instance, +15551234567).",
+    excludeFromMobile: true,
+  },
+  sms_webhook_url: {
+    type: "String",
+    label: "SMS webhook URL",
+    default: "",
+    blurb:
+      "For a custom or unsupported SMS provider. Saltcorn will POST JSON <code>{ to, body }</code> to this URL to send a message.",
+    excludeFromMobile: true,
+  },
   custom_ssl_certificate: {
     type: "String",
     fieldview: "textarea",

--- a/packages/saltcorn-data/models/sms.ts
+++ b/packages/saltcorn-data/models/sms.ts
@@ -1,0 +1,86 @@
+/**
+ * SMS sending
+ * @category saltcorn-data
+ * @module models/sms
+ * @subcategory models
+ */
+import { getState } from "../db/state.js";
+import fetchLib from "node-fetch";
+const fetch: any = fetchLib; // NodeNext default-import interop for node-fetch
+
+/**
+ * Result of a send SMS attempt
+ */
+type SmsResult = {
+  success: boolean;
+  sid?: string;
+};
+
+/**
+ * Send an SMS message via the Twilio Messages API
+ * @param to recipient phone number, in E.164 format
+ * @param body message text
+ */
+const sendViaTwilio = async (to: string, body: string): Promise<SmsResult> => {
+  const accountSid = getState()!.getConfig("twilio_account_sid");
+  const authToken = getState()!.getConfig("twilio_auth_token");
+  const from = getState()!.getConfig("twilio_from_number");
+  if (!accountSid || !authToken || !from)
+    throw new Error(
+      "Twilio SMS is not configured. Set Account SID, Auth token and From number in Settings > SMS."
+    );
+  const resp = await fetch(
+    `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`,
+    {
+      method: "POST",
+      headers: {
+        Authorization:
+          "Basic " +
+          Buffer.from(`${accountSid}:${authToken}`).toString("base64"),
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({ To: to, From: from, Body: body }),
+    }
+  );
+  const json: any = await resp.json();
+  if (!resp.ok)
+    throw new Error(json?.message || `Twilio error (HTTP ${resp.status})`);
+  return { success: true, sid: json.sid };
+};
+
+/**
+ * Send an SMS message via a user-configured generic webhook.
+ * Saltcorn POSTs JSON <code>{ to, body }</code> to the configured URL.
+ * @param to recipient phone number
+ * @param body message text
+ */
+const sendViaWebhook = async (to: string, body: string): Promise<SmsResult> => {
+  const url = getState()!.getConfig("sms_webhook_url");
+  if (!url)
+    throw new Error(
+      "SMS webhook URL is not configured. Set it in Settings > SMS."
+    );
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ to, body }),
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(`SMS webhook error (HTTP ${resp.status}): ${text}`);
+  }
+  return { success: true };
+};
+
+/**
+ * Send an SMS message using the configured SMS provider (Settings > SMS)
+ * @param to recipient phone number
+ * @param body message text
+ */
+const sendSMS = async (to: string, body: string): Promise<SmsResult> => {
+  const provider = getState()!.getConfig("sms_provider") || "Twilio";
+  if (provider === "Generic webhook") return await sendViaWebhook(to, body);
+  return await sendViaTwilio(to, body);
+};
+
+export { sendSMS };

--- a/packages/saltcorn-data/tests/actions.test.ts
+++ b/packages/saltcorn-data/tests/actions.test.ts
@@ -1,3 +1,4 @@
+import http from "http";
 import Trigger from "../models/trigger.js";
 import Table from "../models/table.js";
 import Field from "../models/field.js";
@@ -36,6 +37,7 @@ const {
   emit_event,
   notify_user,
   run_js_code,
+  send_sms,
 } = baseactions;
 import * as utils from "../utils.js";
 import Notification from "../models/notification.js";
@@ -530,6 +532,201 @@ describe("base plugin actions", () => {
 
   //TODO recalculate_stored_fields, set_user_language
 });
+
+describe("send_sms action", () => {
+  let server: any;
+  let port: number;
+  let received: any;
+
+  beforeAll((done: any) => {
+    server = http.createServer((req: any, res: any) => {
+      let body = "";
+      req.on("data", (chunk: any) => (body += chunk));
+      req.on("end", () => {
+        received = JSON.parse(body);
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+      });
+    });
+    server.listen(0, () => {
+      port = server.address().port;
+      done();
+    });
+  });
+
+  afterAll((done: any) => {
+    server.close(done);
+  });
+
+  it("should have valid configFields in table mode", async () => {
+    const patients = Table.findOne({ name: "patients" })!;
+    assertIsSet(patients);
+    const fields = await send_sms.configFields({
+      table: patients,
+      mode: "table",
+    });
+    const names = fields.map((f: any) => f.name);
+    expect(names).toContain("to_phone");
+    expect(names).toContain("to_phone_field");
+    expect(names).toContain("to_phone_fixed");
+    expect(names).toContain("body");
+  });
+
+  it("should have valid configFields in workflow mode", async () => {
+    const fields = await send_sms.configFields({ mode: "workflow" });
+    const names = fields.map((f: any) => f.name);
+    expect(names).toStrictEqual(["to_phone", "body", "confirm_field"]);
+  });
+
+  it("should send via generic webhook with fixed number", async () => {
+    await getState()!.setConfig("sms_provider", "Generic webhook");
+    await getState()!.setConfig(
+      "sms_webhook_url",
+      `http://localhost:${port}`
+    );
+
+    const patients = Table.findOne({ name: "patients" })!;
+    assertIsSet(patients);
+    const row = await patients.getRow({ name: "Simon1" });
+    assertIsSet(row);
+
+    const result = await send_sms.run({
+      row,
+      table: patients,
+      configuration: {
+        to_phone: "Fixed",
+        to_phone_fixed: "+15551234567",
+        body: "Hello {{name}}",
+      },
+      user: { id: 1, role_id: 1 },
+    } as any);
+
+    expect(received).toStrictEqual({
+      to: "+15551234567",
+      body: "Hello Simon1",
+    });
+    expect(result).toStrictEqual({ notify: "SMS sent to +15551234567" });
+
+    await getState()!.setConfig("sms_provider", "Twilio");
+    await getState()!.setConfig("sms_webhook_url", "");
+  });
+
+  it("should send via generic webhook with number from field", async () => {
+    await getState()!.setConfig("sms_provider", "Generic webhook");
+    await getState()!.setConfig(
+      "sms_webhook_url",
+      `http://localhost:${port}`
+    );
+
+    const patients = Table.findOne({ name: "patients" })!;
+    assertIsSet(patients);
+    const row = await patients.getRow({ name: "Simon1" });
+    assertIsSet(row);
+
+    const result = await send_sms.run({
+      row,
+      table: patients,
+      configuration: {
+        to_phone: "Field",
+        to_phone_field: "name",
+        body: "Hi there",
+      },
+      user: { id: 1, role_id: 1 },
+    } as any);
+
+    expect(received).toStrictEqual({ to: "Simon1", body: "Hi there" });
+    expect(result).toStrictEqual({ notify: "SMS sent to Simon1" });
+
+    await getState()!.setConfig("sms_provider", "Twilio");
+    await getState()!.setConfig("sms_webhook_url", "");
+  });
+
+  it("should not send when only_if is false", async () => {
+    await getState()!.setConfig("sms_provider", "Generic webhook");
+    await getState()!.setConfig(
+      "sms_webhook_url",
+      `http://localhost:${port}`
+    );
+    received = undefined;
+
+    const patients = Table.findOne({ name: "patients" })!;
+    assertIsSet(patients);
+    const row = await patients.getRow({ name: "Simon1" });
+    assertIsSet(row);
+
+    const result = await send_sms.run({
+      row,
+      table: patients,
+      configuration: {
+        to_phone: "Fixed",
+        to_phone_fixed: "+15551234567",
+        body: "Hi",
+        only_if: "false",
+      },
+      user: { id: 1, role_id: 1 },
+    } as any);
+
+    expect(result).toBe(undefined);
+    expect(received).toBe(undefined);
+
+    await getState()!.setConfig("sms_provider", "Twilio");
+    await getState()!.setConfig("sms_webhook_url", "");
+  });
+
+  it("should throw if webhook URL is not configured", async () => {
+    await getState()!.setConfig("sms_provider", "Generic webhook");
+    await getState()!.setConfig("sms_webhook_url", "");
+
+    const patients = Table.findOne({ name: "patients" })!;
+    assertIsSet(patients);
+    const row = await patients.getRow({ name: "Simon1" });
+    assertIsSet(row);
+
+    await expect(
+      (async () =>
+        await send_sms.run({
+          row,
+          table: patients,
+          configuration: {
+            to_phone: "Fixed",
+            to_phone_fixed: "+15551234567",
+            body: "Hi",
+          },
+          user: { id: 1, role_id: 1 },
+        } as any))()
+    ).rejects.toThrow();
+
+    await getState()!.setConfig("sms_provider", "Twilio");
+  });
+
+  it("should send via generic webhook in workflow mode", async () => {
+    await getState()!.setConfig("sms_provider", "Generic webhook");
+    await getState()!.setConfig(
+      "sms_webhook_url",
+      `http://localhost:${port}`
+    );
+
+    const result = await send_sms.run({
+      row: { name: "Workflowy" },
+      configuration: {
+        to_phone: "+15559876543",
+        body: "Hello {{name}}",
+      },
+      user: { id: 1, role_id: 1 },
+      mode: "workflow",
+    } as any);
+
+    expect(received).toStrictEqual({
+      to: "+15559876543",
+      body: "Hello Workflowy",
+    });
+    expect(result).toBe(undefined);
+
+    await getState()!.setConfig("sms_provider", "Twilio");
+    await getState()!.setConfig("sms_webhook_url", "");
+  });
+});
+
 describe("run_js_code", () => {
   it("should return value", async () => {
     const rres = await run_js_code.run({

--- a/packages/server/markup/admin.ts
+++ b/packages/server/markup/admin.ts
@@ -479,6 +479,7 @@ const send_admin_page = (
       { text: "Site identity", href: "/admin" },
       { text: "Backup", href: "/admin/backup" },
       { text: "Email", href: "/admin/email" },
+      { text: "SMS", href: "/admin/sms" },
       { text: "System", href: "/admin/system" },
       { text: "Mobile app", href: "/admin/build-mobile-app" },
       { text: "Development", href: "/admin/dev" },

--- a/packages/server/routes/admin.ts
+++ b/packages/server/routes/admin.ts
@@ -103,6 +103,7 @@ const packagejson = require("../../package.json");
 import Form from "@saltcorn/data/models/form";
 import { get_latest_npm_version } from "@saltcorn/data/models/config";
 import { getMailTransport, getOauth2Client } from "@saltcorn/data/models/email";
+import { sendSMS } from "@saltcorn/data/models/sms";
 import {
   getBaseDomain,
   hostname_matches_baseurl,
@@ -351,6 +352,78 @@ router.get(
         : {}),
     });
     res.redirect(authorizeUrl);
+  })
+);
+
+admin_config_route({
+  router,
+  path: "/sms",
+  super_path: "/admin",
+  flash: "SMS settings updated",
+  field_names: [
+    "sms_provider",
+    {
+      name: "twilio_account_sid",
+      showIf: { sms_provider: "Twilio" },
+    },
+    { name: "twilio_auth_token", showIf: { sms_provider: "Twilio" } },
+    { name: "twilio_from_number", showIf: { sms_provider: "Twilio" } },
+    {
+      name: "sms_webhook_url",
+      showIf: { sms_provider: "Generic webhook" },
+    },
+  ],
+  response(form, req, res) {
+    send_admin_page({
+      res,
+      req,
+      active_sub: "SMS",
+      contents: {
+        type: "card",
+        title: req.__("SMS settings"),
+        titleAjaxIndicator: true,
+        contents: [
+          renderForm(form, req.csrfToken()),
+          a(
+            {
+              id: "testsms",
+              href: "/admin/send-test-sms",
+              class: "btn btn-primary",
+              onclick: "spin_action_link(this)",
+            },
+            req.__("Send test SMS")
+          ),
+        ],
+      },
+    });
+  },
+});
+
+/**
+ * @name get/send-test-sms
+ * @function
+ * @memberof module:routes/admin~routes/adminRouter
+ */
+router.get(
+  "/send-test-sms",
+  isAdmin,
+  error_catcher(async (req: Req, res: Res) => {
+    const to = req.query!.to as string;
+    if (!to) {
+      req.flash(
+        "error",
+        req.__("Add ?to=+15551234567 to the URL with your phone number")
+      );
+      return res.redirect("/admin/sms");
+    }
+    try {
+      await sendSMS(to, req.__("Hello from Saltcorn"));
+      req.flash("success", req.__("SMS sent to %s with no errors", to));
+    } catch (e: any) {
+      getState()!.log(2, `send-test-sms error: ${e.message}`);
+      req.flash("error", e.message);
+    }
+    res.redirect("/admin/sms");
   })
 );
 


### PR DESCRIPTION
## Summary
- Adds a built-in "Send SMS" action alongside the existing "Send email" action, usable from table triggers, workflow steps, and action buttons.
- Sends via Twilio's Messages API by default, or a generic JSON webhook (`{ to, body }`) for any other SMS provider — no plugin install required.
- New **Settings → SMS** admin page for provider configuration (Twilio Account SID/Auth token/From number, or a webhook URL) with a "Send test SMS" button.
- Recipient number can be a fixed value or read from a String field on the row, with `{{ }}` interpolation in the message body, an "only if" formula, and a confirmation field — mirroring the existing `send_email` action's shape.

## Motivation
Closes #4272, where a user asked how to send SMS from Saltcorn. The community-suggested plugin (`@saltcorn/twilio-verify-sms`) wraps Twilio's *Verify* API for OTP flows specifically, isn't listed in the module store, and doesn't cover sending arbitrary text messages. This adds a general-purpose, in-core alternative that works immediately with any SMS provider.

## Test plan
- [x] `packages/saltcorn-data/tests/actions.test.ts` — new `send_sms action` suite covering `configFields` in both table/workflow modes, sending via a mock local HTTP server (fixed number, field-sourced number, workflow mode), the `only_if` guard, and the "not configured" error path.
- [x] `tsc` passes with no new errors introduced by this change (verified against a clean baseline).
- [ ] Manual verification in a running instance (Settings → SMS → configure webhook/Twilio → add a "Send SMS" trigger).

Closes #4272