### PR TITLE
fix: sanitize composite primary key column names in postgres update()

### DIFF
--- a/packages/postgres/postgres.ts
+++ b/packages/postgres/postgres.ts
@@ -424,7 +424,7 @@ export const update = async (
     const whereStrs: string[] = [];
     Object.keys(id).forEach((k) => {
       valList.push(id[k]);
-      whereStrs.push(`"${k}"=$${n}`);
+      whereStrs.push(`"${sqlsanitize(k)}"=$${n}`);
       n += 1;
     });
     whereS = whereStrs.join(" and ");


### PR DESCRIPTION
## Summary
- `packages/postgres/postgres.ts` `update()`: the composite-primary-key branch (`typeof id === "object"`) built its WHERE clause column identifiers directly from `Object.keys(id)`, the one identifier-construction site in this file not passed through `sqlsanitize()` — every other one (table name, column assigns, single `pk_name` via `ppPK`) already is.

## Motivation
Not currently reachable with attacker-controlled input: these keys are only ever populated from `Table.composite_pk_names`, i.e. admin-defined primary key field names chosen when the table schema was created (`packages/saltcorn-data/models/table.ts`). This is a defensive-consistency fix, not a response to an active exploit path.

## Test plan
- [x] `tsc` on the changed file shows no new errors (remaining errors are pre-existing missing `@types` declarations for `pg`/`pg-copy-streams`/`replacestream`, unrelated to this change).
- [x] Confirmed no other identifier-construction site in this file is missing the sanitize call.