### PR TITLE
fix #4115: put form-control on the monaco wrapper instead of editor

### DIFF
--- a/packages/server/public/saltcorn-common.js
+++ b/packages/server/public/saltcorn-common.js
@@ -1527,17 +1527,19 @@ ${value}`;
         if (singleline) {
           div.style.height = "30px";
         }
-        const editor = monaco.editor.create(div, {
+        let host = div;
+        if (singleline || compact) {
+          div.classList.add("form-control", "p-0", "pt-1");
+          host = document.createElement("div");
+          host.style.height = "100%";
+          div.appendChild(host);
+        }
+        const editor = monaco.editor.create(host, {
           value,
           language,
           theme: _sc_lightmode === "dark" ? "vs-dark" : "vs",
           minimap: { enabled: false },
-          ...(singleline || compact
-            ? {
-                extraEditorClassName: "form-control",
-                ...singleLineMonacoEditorOptions,
-              }
-            : {}),
+          ...(singleline || compact ? singleLineMonacoEditorOptions : {}),
         });
         $(div).data("monaco-editor", editor);
         monaco.languages.typescript.typescriptDefaults.setCompilerOptions({


### PR DESCRIPTION
Fixed the monaco renderings
<img width="785" height="155" alt="one-line" src="https://github.com/user-attachments/assets/02f9673b-dd5e-4f95-8c55-f56b2b199475" />
<img width="800" height="275" alt="multi-line" src="https://github.com/user-attachments/assets/098ae53a-31c6-450c-a8bd-eebbb5fa95a0" />
