### PR TITLE
fix(packs): list triggers alphabetically on the Create Pack screen

### DIFF
--- a/packages/server/routes/packs.ts
+++ b/packages/server/routes/packs.ts
@@ -112,7 +112,16 @@ router.get(
       name: `library.${l.name}`,
       type: "Bool",
     }));
-    const trigs = (await Trigger.find({}))!;
+    // Sorted here rather than in `Trigger.find`, which every other caller shares.
+    //
+    // The other groups on this screen come back ordered because they are DB queries;
+    // `Trigger.find` filters an in-memory array held on state, so triggers arrived in
+    // whatever order they were loaded and were the one unsorted group on the Create Pack
+    // screen. Changing the shared finder's order to fix one screen would be a wider
+    // behaviour change than this asks for.
+    const trigs = (await Trigger.find({}))!.sort((a: any, b: any) =>
+      String(a.name ?? "").localeCompare(String(b.name ?? ""))
+    );
     const trigFields = trigs.map((l: any) => ({
       label: `${l.name} trigger`,
       name: `trigger.${l.name}`,


### PR DESCRIPTION
## What

Triggers are now sorted by name on the Create Pack screen.

Fixes #4352.

## Why they were the odd one out

Every other group on that screen (views, plugins, pages, page groups, libraries, roles) comes back ordered because each is a **DB query**. `Trigger.find` is different — it filters an in-memory array held on state:

```ts
static find(where?: Where): Trigger[] {
  return getState()!.triggers.filter(satisfies(where));
}
```

So triggers arrived in whatever order they happened to be loaded, which is why they were the single unsorted group.

## Sorted at the screen, not in the finder

`Trigger.find` is shared by every other caller in the codebase. Changing its ordering to fix one screen would be a much wider behaviour change than this issue asks for, and a silent one — so the sort lives in `packs.ts`, where the list is built.

`localeCompare` rather than `<`, so names sort the way a reader expects rather than by code point, and a missing name degrades to `""` instead of throwing.

## Verification

- `tsc --noEmit` on `packages/server` — no errors in `packs.ts`
- `eslint` on the changed file — clean

One note: `prettier --check packages/server/routes/packs.ts` **already fails on `master`** before my change. I left that alone rather than reformatting the file, since doing so would bury a four-line fix in an unrelated whole-file diff. Happy to send the reformat separately if you want it.