### PR TITLE
Add copilot hooks to viewtemplates, fix empty default-state filter

### DIFF
--- a/packages/saltcorn-data/base-plugin/viewtemplates/edit.ts
+++ b/packages/saltcorn-data/base-plugin/viewtemplates/edit.ts
@@ -2052,6 +2052,14 @@ export default {
   name: "Edit",
   /** @type {string} */
   description: "Form for creating a new row or editing existing rows",
+  copilot_layout_rule:
+    "Never use the GoBack action for a cancel button - it always calls history.back(), which " +
+    "breaks when the view is opened inside a popup modal. Instead add a link segment whose " +
+    "url is this JavaScript (closes the Saltcorn modal #scmodal if open, else history.back()): " +
+    "javascript:var m=document.getElementById('scmodal');var mi=m&&bootstrap.Modal.getInstance(m);" +
+    "if(mi)mi.hide();else history.back() - style it as btn btn-outline-secondary. This is a " +
+    "single-record create/edit form, never a bulk CSV import tool - CSV import belongs on a " +
+    "dedicated admin page using an installed import/export viewtemplate.",
   configuration_workflow,
   run,
   runMany,

--- a/packages/saltcorn-data/base-plugin/viewtemplates/list.ts
+++ b/packages/saltcorn-data/base-plugin/viewtemplates/list.ts
@@ -570,17 +570,39 @@ const configuration_workflow = (req: Req) =>
           )!;
           const table_fields = table
             .getFields()
-            .filter((f: GenObj) => !f.calculated || f.stored);
+            // Excluded here, not marked - Form/Field strips unknown properties on any field.
+            .filter((f: GenObj) => (!f.calculated || f.stored) && f.name !== "id");
+          // Offering blank as a real enum option beats telling an AI to omit the property.
+          const withBlankOption = (options: any) => {
+            if (!options) return options;
+            if (typeof options === "string")
+              return options.trim().startsWith(",") ? options : `,${options}`;
+            if (Array.isArray(options))
+              return options.some((o: any) =>
+                (typeof o === "string" ? o : o?.value) === ""
+              )
+                ? options
+                : ["", ...options];
+            return options;
+          };
           const formfields = table_fields.map((f: GenObj) => {
+            const attributes =
+              context.copilot_call && f.attributes?.options
+                ? { ...f.attributes, options: withBlankOption(f.attributes.options) }
+                : f.attributes;
             return {
               name: f.name,
               label: f.label,
               type: f.type,
               reftable_name: f.reftable_name,
-              attributes: f.attributes,
+              attributes,
               fieldview:
                 f.type && f.type.name === "Bool" ? "tristate" : undefined,
               required: false,
+              copilot_description:
+                `Omit this property entirely by default - a default state is not needed ` +
+                `for ${f.name}. Only include it if the task explicitly requires the list ` +
+                `to default to a fixed ${f.name} value on load.`,
             };
           });
           const form = new Form({
@@ -1857,6 +1879,45 @@ export default {
   name: "List",
   description:
     "Display multiple rows from a table in a grid with columns you specify",
+  copilot_planning_rule:
+    "A List view should always have a viewlink column to a Show (detail) view, named by " +
+    "its exact snake_case task name - never a vague reference like \"a detail view\". Add " +
+    "a viewlink column to an Edit view too, but only when this List's own role (min_role) " +
+    "is numerically <= the table's min_role_write shown above - a role above that number " +
+    "cannot write to the table regardless of any view's own min_role. This List's task " +
+    "depends on every view it links to - you MUST include their exact names in this task's " +
+    "depends_on. Example: a min_role 1 tasks_admin_list depends_on [\"tasks_show\", " +
+    "\"tasks_edit\"]; a min_role 80 tasks_user_list (table min_role_write 40) depends_on " +
+    "only [\"tasks_show\"]. " +
+    "include_fml (set in this viewtemplate's Options step) permanently scopes which " +
+    "rows a List shows, e.g. an owner/assignee FK check like \"<fk_field> === user.id\" - a " +
+    "List scoped to a different include_fml value is a different view and needs its own " +
+    "task; never reuse one List's task for two scoping needs.",
+  copilot_layout_rule:
+    "If required, the viewlink and delete action segments must actually be present in this " +
+    "layout - they are derived into columns from it, not from the task description alone. " +
+    "Never include the `id` field - it's an internal implementation detail, not for display. " +
+    "There is no built-in CSV export - never add an export button or column here; put " +
+    "import/export on a dedicated admin page using an installed import/export viewtemplate " +
+    "instead. A Link column that navigates to a page (not a view - use ViewLink for that) " +
+    "with the current row id needs a JS template-literal URL formula (isFormula.url = true), " +
+    "e.g. `/page/order_detail?id=${id}` - static strings are not interpolated and `{{id}}` " +
+    "does not work here. Both the columns array entry and the matching layout.besides " +
+    "segment need url, text, and isFormula set consistently, e.g.: " +
+    '{"type":"Link","url":"`/page/order_detail?id=${id}`","text":"Detail",' +
+    '"link_src":"URL","link_style":"btn btn-sm btn-outline-secondary","isFormula":{"url":true}}.',
+  copilot_generate_view_prompt:
+    "If this List must show only rows matching a condition (e.g. the logged-in user's own " +
+    "rows), set include_fml in the Options step to the matching JS boolean expression (e.g. " +
+    "\"assignee === user.id\") now - do not leave it for a later step, and never use " +
+    "extra_state_fml instead, which is an unrelated embed-segment property. In " +
+    "create_view_showif (and any other showif/formula field evaluated against the URL " +
+    "state), the variable `state` does not exist - the state object is passed as `row`, and " +
+    "each key is also available as a bare variable; use `row.project_id` or `project_id`, " +
+    "never `state.project_id`. The Default state step is one optional pre-filter field per " +
+    "table column, applied before any user search when the list first loads - omit every " +
+    "column by default (do not pick an enum value just because one is available), and only " +
+    "include one if the task explicitly requires that exact value on load.",
   configuration_workflow,
   run,
   view_quantity: "Many",

--- a/packages/saltcorn-data/base-plugin/viewtemplates/show.ts
+++ b/packages/saltcorn-data/base-plugin/viewtemplates/show.ts
@@ -851,7 +851,15 @@ export default {
     "in the layout - it's an internal implementation detail, not for display. To show " +
     "related rows, embed a List view for them, not an Edit view - an Edit view embedded here " +
     "renders a form with inputs and save buttons inline in a read display, which is wrong " +
-    "except for a deliberate inline-edit pattern the task explicitly asks for.",
+    "except for a deliberate inline-edit pattern the task explicitly asks for. A literal " +
+    "label or other static text is a blank segment (e.g. {\"type\":\"blank\",\"contents\":" +
+    "\"Category\"}) - there is no \"text\" segment type, never emit {\"type\":\"text\"}. A " +
+    "field reached through a foreign key is a join_field segment (e.g. {\"type\":" +
+    "\"join_field\",\"join_field\":\"category_id.description\"}) paired with a matching " +
+    "JoinField entry (same join_field path) in configuration.columns - use this native pair " +
+    "instead of writing {{category_id.description}} in a blank segment. Keep every existing " +
+    "configuration.columns entry unless the task explicitly removes it, and add a Field or " +
+    "JoinField entry for every field/join_field segment you add to the layout.",
   get_state_fields,
   configuration_workflow,
   run,

--- a/packages/saltcorn-data/base-plugin/viewtemplates/show.ts
+++ b/packages/saltcorn-data/base-plugin/viewtemplates/show.ts
@@ -840,6 +840,18 @@ const createBasicView = async ({
 export default {
   name: "Show",
   description: "Show a single row, with flexible layout",
+  copilot_planning_rule:
+    "When a Show view needs to display related rows (e.g. an invoice's line items), that's a " +
+    "separate List view task for the related table, planned and created before this Show " +
+    "view's task, named in its depends_on.",
+  copilot_layout_rule:
+    "Every field is its own segment with \"type\": \"field\" (singular) - there is no " +
+    "\"type\": \"fields\" (plural) segment, and using it crashes with \"unknown layout " +
+    "segment\". Never bundle multiple fields into one segment. Never include the `id` field " +
+    "in the layout - it's an internal implementation detail, not for display. To show " +
+    "related rows, embed a List view for them, not an Edit view - an Edit view embedded here " +
+    "renders a form with inputs and save buttons inline in a read display, which is wrong " +
+    "except for a deliberate inline-edit pattern the task explicitly asks for.",
   get_state_fields,
   configuration_workflow,
   run,

--- a/packages/saltcorn-data/models/field.ts
+++ b/packages/saltcorn-data/models/field.ts
@@ -87,6 +87,7 @@ class Field implements AbstractField {
   default?: any;
   sublabel?: string;
   description?: string;
+  copilot_description?: string;
   type?: string | Type;
   typename?: string;
   help?: { topic: string; context?: Row; dynContext?: string[] };
@@ -138,6 +139,7 @@ class Field implements AbstractField {
     this.default = o.default;
     this.sublabel = o.sublabel;
     this.description = o.description;
+    this.copilot_description = o.copilot_description;
 
     this.type = typeof o.type === "string" ? getState()!.types[o.type] : o.type;
     if (!this.type)

--- a/packages/saltcorn-data/models/view.ts
+++ b/packages/saltcorn-data/models/view.ts
@@ -905,6 +905,7 @@ class View implements AbstractView {
     Object.entries(defstate || {}).forEach(([k, v]) => {
       if (
         typeof state[k] === "undefined" &&
+        v !== "" &&
         !(typeof v === "object" && v && !Object.keys(v).length)
       ) {
         state[k] = v;

--- a/packages/saltcorn-types/base_types.ts
+++ b/packages/saltcorn-types/base_types.ts
@@ -315,9 +315,9 @@ export type ViewTemplate = {
   name: string;
   description?: string;
   // Used when the app constructor generates a task
-  copilot_planning_rule?: string;
+  copilot_planning_rule?: string | ((input: any) => Promise<string> | string);
   // Used when the app constructor executes a task where a view gets generated
-  copilot_layout_rule?: string;
+  copilot_layout_rule?: string | ((input: any) => Promise<string> | string);
   // Used when the app constructor fills out the fields of a view config form
   copilot_generate_view_prompt?:
     | string

--- a/packages/saltcorn-types/base_types.ts
+++ b/packages/saltcorn-types/base_types.ts
@@ -314,6 +314,14 @@ export type Action = {
 export type ViewTemplate = {
   name: string;
   description?: string;
+  // Used when the app constructor generates a task
+  copilot_planning_rule?: string;
+  // Used when the app constructor executes a task where a view gets generated
+  copilot_layout_rule?: string;
+  // Used when the app constructor fills out the fields of a view config form
+  copilot_generate_view_prompt?:
+    | string
+    | ((input: any) => Promise<string> | string);
   tableless?: boolean;
   table_optional?: boolean;
   singleton?: boolean;

--- a/packages/saltcorn-types/model-abstracts/abstract_field.ts
+++ b/packages/saltcorn-types/model-abstracts/abstract_field.ts
@@ -20,6 +20,7 @@ export interface AbstractField {
   id?: PrimaryKeyValue;
   options?: string[];
   showIf?: Record<string, any>;
+  copilot_description?: string;
 }
 
 export type FieldCfg = {
@@ -40,6 +41,7 @@ export type FieldCfg = {
   sublabel?: string;
   help?: { topic: string; context?: Row; dynContext?: string[] };
   description?: string;
+  copilot_description?: string;
   type?: string | Type;
   options?: Array<string | { label: string; value: string }>;
   required?: boolean;


### PR DESCRIPTION
- New ViewTemplate fields: copilot_planning_rule, copilot_layout_rule, copilot_generate_view_prompt
- New Field property: copilot_description, preserved through Form/Field construction (previously silently dropped)
- List: viewlink/dependency guidance tied to min_role_write, with examples; include_fml notes; safer Default state step (no id field, blank option offered only for AI-driven calls)
- Show: related-rows-need-their-own-List-task guidance; layout segment schema notes
- Edit: modal-safe cancel button guidance; not-a-bulk-import-tool note
- Fix: empty default-state value no longer treated as a real row filter (was producing zero-row lists)